### PR TITLE
replace all prisma findUnique with findFirst

### DIFF
--- a/src/app/api/lists/[listId]/route.ts
+++ b/src/app/api/lists/[listId]/route.ts
@@ -12,7 +12,7 @@ export const PATCH = withApiHandling(async (_req: NextRequest, { params }) => {
 
   // verify list exists and belongs to current user
   const { listId } = routeParams
-  const list = await prisma.list.findUnique({
+  const list = await prisma.list.findFirst({
     where: {
       id: listId,
     },
@@ -54,7 +54,7 @@ export const DELETE = withApiHandling(
 
     // verify list exists and belongs to current user
     const { listId } = routeParams
-    const list = await prisma.list.findUnique({
+    const list = await prisma.list.findFirst({
       where: {
         id: listId,
       },

--- a/src/app/api/pins/route.ts
+++ b/src/app/api/pins/route.ts
@@ -13,7 +13,7 @@ export const POST = withApiHandling(async (_req: NextRequest, { params }) => {
 
   // verify pinned object exists and belongs to the user
   if (pinnedObjectType === "list") {
-    const pinnedObject = await prisma.list.findUnique({
+    const pinnedObject = await prisma.list.findFirst({
       where: {
         id: pinnedObjectId,
       },

--- a/src/app/books/[bookSlug]/page.tsx
+++ b/src/app/books/[bookSlug]/page.tsx
@@ -11,7 +11,7 @@ const prisma = new PrismaClient()
 export default async function BookPageBySlug({ params }: any) {
   const { bookSlug } = params
 
-  const book = await prisma.book.findUnique({
+  const book = await prisma.book.findFirst({
     where: {
       slug: bookSlug,
     },

--- a/src/app/users/[username]/lists/[listSlug]/edit/page.tsx
+++ b/src/app/users/[username]/lists/[listSlug]/edit/page.tsx
@@ -14,7 +14,7 @@ export default async function UserListPage({ params }) {
   const currentUserProfile = await getCurrentUserProfile()
   if (!currentUserProfile) redirect("/")
 
-  const userProfile = await prisma.userProfile.findUnique({
+  const userProfile = await prisma.userProfile.findFirst({
     where: {
       username,
     },

--- a/src/app/users/[username]/lists/[listSlug]/page.tsx
+++ b/src/app/users/[username]/lists/[listSlug]/page.tsx
@@ -17,7 +17,7 @@ export default async function UserListPage({ params }) {
 
   const currentUserProfile = await getCurrentUserProfile()
 
-  const userProfile = await prisma.userProfile.findUnique({
+  const userProfile = await prisma.userProfile.findFirst({
     where: {
       username,
     },

--- a/src/app/users/[username]/lists/page.tsx
+++ b/src/app/users/[username]/lists/page.tsx
@@ -12,7 +12,7 @@ export default async function UserListsIndexPage({ params }) {
   const { username } = params
   const currentUserProfile = await getCurrentUserProfile()
 
-  const userProfile = await prisma.userProfile.findUnique({
+  const userProfile = await prisma.userProfile.findFirst({
     where: {
       username,
     },

--- a/src/app/users/[username]/page.tsx
+++ b/src/app/users/[username]/page.tsx
@@ -19,7 +19,7 @@ export default async function UserProfilePage({ params }) {
   const { username } = params
   const currentUserProfile = await getCurrentUserProfile()
 
-  const userProfile = await prisma.userProfile.findUnique({
+  const userProfile = await prisma.userProfile.findFirst({
     where: {
       username,
     },

--- a/src/lib/api/withApiHandling.ts
+++ b/src/lib/api/withApiHandling.ts
@@ -37,7 +37,7 @@ export function withApiHandling(requestHandler, options: Options = defaults) {
       const { session } = humps.camelizeKeys(data)
       if (!session && requireSession) throw new Error("No session found")
 
-      const currentUserProfile = await prisma.userProfile.findUnique({
+      const currentUserProfile = await prisma.userProfile.findFirst({
         where: { userId: session.user.id },
       })
       if (!currentUserProfile && requireUserProfile) throw new Error("User profile not found")

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -27,7 +27,7 @@ const getCurrentUserProfile = async (options: Options = defaultOptions) => {
 
   const sessionUserId = session?.user?.id
 
-  const currentUserProfile = await prisma.userProfile.findUnique({
+  const currentUserProfile = await prisma.userProfile.findFirst({
     where: {
       userId: sessionUserId,
     },


### PR DESCRIPTION
`findUnique` only adds a prisma validation (that the query is using unique columns) that's unnecessary and seems to over-aggressively throw errors