### PR TITLE
don't sort search results by edition count

### DIFF
--- a/src/lib/openlibrary.ts
+++ b/src/lib/openlibrary.ts
@@ -107,8 +107,6 @@ const OpenLibrary = {
 
     const books: Partial<Book>[] = []
 
-    results.sort((a, b) => b.editionCount - a.editionCount)
-
     // filter out unreliable results and apply limit
     // so far some markers of unreliable results (based on trial and error) include:
     // + no isbn


### PR DESCRIPTION
it turns out the openlibrary search's natural ranking is decent enough, and forcing a specific sort order only messes it up