### PR TITLE
support book reads without dates

### DIFF
--- a/prisma/migrations/20231214230102_add_status_to_book_reads/migration.sql
+++ b/prisma/migrations/20231214230102_add_status_to_book_reads/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `status` to the `book_reads` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "book_reads" ADD COLUMN     "status" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -143,6 +143,7 @@ model BookRead {
   id        String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   readerId  String      @map("reader_id") @db.Uuid
   bookId    String      @map("book_id") @db.Uuid
+  status    String
   startDate DateTime?   @map("start_date") @db.Timestamptz(6)
   endDate   DateTime?   @map("end_date") @db.Timestamptz(6)
   createdAt DateTime    @default(now()) @map("created_at") @db.Timestamptz(6)

--- a/src/app/api/book_reads/route.ts
+++ b/src/app/api/book_reads/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server"
+import humps from "humps"
+import prisma from "lib/prisma"
+import { withApiHandling } from "lib/api/withApiHandling"
+import type { NextRequest } from "next/server"
+
+export const GET = withApiHandling(
+  async (_req: NextRequest, { params }) => {
+    const { currentUserProfile } = params
+    const queryParams = _req.nextUrl.searchParams
+    const bookId = queryParams.get("book_id") || undefined
+    const forCurrentUser = queryParams.get("for_current_user") === "true"
+
+    if (!bookId && !forCurrentUser) {
+      const errorMsg = "Must provide either book_id or for_current_user query param."
+      return NextResponse.json({ error: errorMsg }, { status: 400 })
+    }
+
+    if (forCurrentUser && !currentUserProfile) {
+      const errorMsg = "Must be logged in to get for_current_user book reads."
+      return NextResponse.json({ error: errorMsg }, { status: 403 })
+    }
+
+    const bookReads = await prisma.bookRead.findMany({
+      where: {
+        bookId,
+        readerId: forCurrentUser ? currentUserProfile.id : undefined,
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    })
+
+    const resBody = humps.decamelizeKeys(bookReads)
+
+    return NextResponse.json(resBody, { status: 200 })
+  },
+  { requireJsonBody: false, requireSession: false, requireUserProfile: false },
+)

--- a/src/app/books/[bookSlug]/page.tsx
+++ b/src/app/books/[bookSlug]/page.tsx
@@ -67,8 +67,6 @@ export default async function BookPageBySlug({ params }: any) {
 
   let book = { ...dbBook, ...openLibraryBook }
 
-  console.log(book)
-
   let userLists: any[] = []
 
   if (userProfile) {
@@ -121,6 +119,7 @@ export default async function BookPageBySlug({ params }: any) {
     sort: Sort.Popular,
     noteTypes: [BookNoteType.JournalEntry],
     currentUserProfile: userProfile,
+    requireText: true,
   })
 
   book.bookPosts = await getBookNotes({
@@ -131,7 +130,6 @@ export default async function BookPageBySlug({ params }: any) {
   })
 
   book = (await decorateWithLikes([book], InteractionObjectType.Book, userProfile))[0]
-  console.log(book)
 
   return (
     <RemountOnPathChange

--- a/src/enums/BookReadStatus.ts
+++ b/src/enums/BookReadStatus.ts
@@ -1,0 +1,7 @@
+enum BookReadStatus {
+  Started = "started",
+  Finished = "finished",
+  Abandoned = "abandoned",
+}
+
+export default BookReadStatus

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -57,6 +57,13 @@ const api = {
         body: prepReqBody(requestData),
       }),
   },
+  bookReads: {
+    get: (params: { bookId?: string; forCurrentUser?: boolean }) => {
+      const queryString = new URLSearchParams(humps.decamelizeKeys(params)).toString()
+      const url = `/api/book_reads?${queryString}`
+      return fetchJson(url)
+    },
+  },
   likes: {
     get: (params: {
       likedObjectId: string

--- a/src/types/BookRead.ts
+++ b/src/types/BookRead.ts
@@ -1,0 +1,18 @@
+import { UserProfileProps as UserProfile } from "lib/models/UserProfile"
+import Book from "types/Book"
+import BookNote from "types/BookNote"
+import BookReadStatus from "enums/BookReadStatus"
+
+export default interface BookRead {
+  id?: string
+  readerId: string
+  bookId: string
+  status: BookReadStatus
+  startDate?: string | Date
+  endDate?: string | Date
+  createdAt: string | Date
+  updatedAt: string | Date
+  reader: UserProfile
+  book: Book
+  bookNotes?: BookNote[]
+}


### PR DESCRIPTION
book reads without dates were technically possible already, though with slightly unpredictable behavior in some cases (because it assumed a book read with no finish date was unfinished); this PR makes it a first-class use case, both UI/UX-wise and data-model-wise.

in LogBookModal, tucks the date fields away, so that you can more easily ignore them if you don't care about dates. still uses sensible defaults, even if you ignore them.

adds `status` field to BookRead, so that we can tell whether a book read is finished or not even without any dates. this is now what's used to identify the last unfinished book read.

also refetches book reads after you create a book note, so that you can create multiple notes attached to the same book read even without refreshing the page.

https://app.asana.com/0/1205114589319956/1206139232817027