### PR TITLE
per-book notes in a list

### DIFF
--- a/prisma/migrations/20231218004716_add_note_to_list_item_assignments/migration.sql
+++ b/prisma/migrations/20231218004716_add_note_to_list_item_assignments/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "list_item_assignments" ADD COLUMN     "note" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,23 +10,23 @@ datasource db {
 
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model UserProfile {
-  id              String              @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  username        String              @unique
-  bio             String?
-  userId          String              @unique @map("user_id") @db.Uuid
-  avatarUrl       String?             @map("avatar_url")
-  displayName     String?             @map("display_name")
-  location        String?
-  website         String?
-  createdAt       DateTime            @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt       DateTime?           @updatedAt @map("updated_at") @db.Timestamptz(6)
-  user            User                @relation(fields: [userId], references: [id], onDelete: Restrict)
-  lists           List[]
-  pins            Pin[]
-  bookNotes       BookNote[]
-  bookReads       BookRead[]
-  currentStatuses UserCurrentStatus[]
-  bookShelfAssignments         UserBookShelfAssignment[]
+  id                   String                    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  username             String                    @unique
+  bio                  String?
+  userId               String                    @unique @map("user_id") @db.Uuid
+  avatarUrl            String?                   @map("avatar_url")
+  displayName          String?                   @map("display_name")
+  location             String?
+  website              String?
+  createdAt            DateTime                  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt            DateTime?                 @updatedAt @map("updated_at") @db.Timestamptz(6)
+  user                 User                      @relation(fields: [userId], references: [id], onDelete: Restrict)
+  lists                List[]
+  pins                 Pin[]
+  bookNotes            BookNote[]
+  bookReads            BookRead[]
+  currentStatuses      UserCurrentStatus[]
+  bookShelfAssignments UserBookShelfAssignment[]
 
   @@map("user_profiles")
 }
@@ -42,25 +42,25 @@ model User {
 }
 
 model Book {
-  id                  String                   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  slug                String                   @unique
-  title               String
-  authorName          String?                  @map("author_name")
-  openLibraryWorkId   String?                  @unique @map("open_library_work_id")
-  coverImageUrl       String?                  @map("cover_image_url")
-  editionsCount       Int?                     @map("editions_count")
-  firstPublishedYear  Int?                     @map("first_published_year")
-  description         String?
-  isTranslated        Boolean                  @default(false) @map("is_translated")
-  originalTitle       String?                  @map("original_title")
-  subtitle            String?
-  titleAuthorSearch   Unsupported("tsvector")? @default(dbgenerated("to_tsvector('english'::regconfig, ((((COALESCE(title, ''::text) || ' '::text) || COALESCE(original_title, ''::text)) || ' '::text) || COALESCE(author_name, ''::text)))")) @map("title_author_search")
-  createdAt           DateTime                 @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt           DateTime?                @updatedAt @map("updated_at") @db.Timestamptz(6)
-  bookNotes           BookNote[]
-  bookReads           BookRead[]
-  userCurrentStatuses UserCurrentStatus[]
-  userShelfAssignments         UserBookShelfAssignment[]
+  id                   String                    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  slug                 String                    @unique
+  title                String
+  authorName           String?                   @map("author_name")
+  openLibraryWorkId    String?                   @unique @map("open_library_work_id")
+  coverImageUrl        String?                   @map("cover_image_url")
+  editionsCount        Int?                      @map("editions_count")
+  firstPublishedYear   Int?                      @map("first_published_year")
+  description          String?
+  isTranslated         Boolean                   @default(false) @map("is_translated")
+  originalTitle        String?                   @map("original_title")
+  subtitle             String?
+  titleAuthorSearch    Unsupported("tsvector")?  @default(dbgenerated("to_tsvector('english'::regconfig, ((((COALESCE(title, ''::text) || ' '::text) || COALESCE(original_title, ''::text)) || ' '::text) || COALESCE(author_name, ''::text)))")) @map("title_author_search")
+  createdAt            DateTime                  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt            DateTime?                 @updatedAt @map("updated_at") @db.Timestamptz(6)
+  bookNotes            BookNote[]
+  bookReads            BookRead[]
+  userCurrentStatuses  UserCurrentStatus[]
+  userShelfAssignments UserBookShelfAssignment[]
 
   @@index([openLibraryWorkId])
   @@index([titleAuthorSearch], type: Gin)
@@ -93,6 +93,7 @@ model ListItemAssignment {
   listedObjectType String    @map("listed_object_type")
   listedObjectId   String    @map("listed_object_id") @db.Uuid
   sortOrder        Int       @map("sort_order")
+  note             String?
   createdAt        DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt        DateTime? @updatedAt @map("updated_at") @db.Timestamptz(6)
   list             List      @relation(fields: [listId], references: [id], onDelete: Cascade)

--- a/src/app/api/lists/[listId]/route.ts
+++ b/src/app/api/lists/[listId]/route.ts
@@ -31,13 +31,14 @@ export const PATCH = withApiHandling(async (_req: NextRequest, { params }) => {
     )
   }
 
-  const { title, description, ranked, books } = reqJson
+  const { title, description, ranked, books, bookNotes } = reqJson
 
   const updatedListParams = {
     title,
     description,
     ranked,
     books,
+    bookNotes,
   }
 
   const updatedList = await updateList(list, updatedListParams, userProfile)

--- a/src/app/api/lists/route.ts
+++ b/src/app/api/lists/route.ts
@@ -6,9 +6,9 @@ import type { NextRequest } from "next/server"
 
 export const POST = withApiHandling(async (_req: NextRequest, { params }) => {
   const { reqJson, currentUserProfile: userProfile } = params
-  const { title, description, ranked, books } = reqJson
+  const { title, description, ranked, books, bookNotes } = reqJson
 
-  const listParams = { title, description, ranked, books }
+  const listParams = { title, description, ranked, books, bookNotes }
   const createdList = await createList(listParams, userProfile)
 
   const resBody = humps.decamelizeKeys(createdList)

--- a/src/app/components/forms/FormTextarea.tsx
+++ b/src/app/components/forms/FormTextarea.tsx
@@ -55,6 +55,7 @@ export default function FormTextarea({
           className={`w-full px-3 pt-3 pb-2 ${bgColor} rounded border-none focus:outline-gold-500 ${moreClasses}`}
         />
         {textFormattingAndRemainingChars}
+        {errorMessage && <div className="my-2 text-red-500">{errorMessage}</div>}
       </div>
     </div>
   )

--- a/src/app/lists/components/GridCardViewToggle.tsx
+++ b/src/app/lists/components/GridCardViewToggle.tsx
@@ -1,0 +1,32 @@
+import { BsGrid, BsListUl } from "react-icons/bs"
+
+export default function GridCardViewToggle({ activeView, onChange }) {
+  const sharedClasses =
+    "relative inline-flex items-center bg-black px-2 py-2 text-white ring-1 ring-inset ring-gray-700 hover:bg-gray-800 focus:z-10"
+  return (
+    <span className="isolate inline-flex rounded-md shadow-sm">
+      <button
+        type="button"
+        title="grid view"
+        onClick={() => onChange("grid")}
+        className={`${sharedClasses} ${
+          activeView === "grid" ? "bg-gray-800" : "bg-black"
+        } rounded-l-sm`}
+      >
+        <span className="sr-only">grid view</span>
+        <BsGrid className="text-sm" aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        title="card view"
+        onClick={() => onChange("card")}
+        className={`${sharedClasses} ${
+          activeView === "card" ? "bg-gray-800" : "bg-black"
+        } rounded-r-sm`}
+      >
+        <span className="sr-only">card view</span>
+        <BsListUl className="text-sm" aria-hidden="true" />
+      </button>
+    </span>
+  )
+}

--- a/src/app/lists/components/ListBookCard.tsx
+++ b/src/app/lists/components/ListBookCard.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link"
+import { getBookLink } from "lib/helpers/general"
+import CoverPlaceholder from "app/components/books/CoverPlaceholder"
+import CustomMarkdown from "app/components/CustomMarkdown"
+
+export default function ListBookCard({ book, note, isRanked = false, rank = 0 }) {
+  const { title, authorName, slug, coverImageUrl } = book
+
+  return (
+    <div className="flex py-6 border-b border-b-gray-500 last:border-none font-newsreader">
+      <div className="shrink-0 w-[72px] xs:w-[96px] ml-4 mr-6">
+        <Link href={getBookLink(slug)}>
+          {coverImageUrl ? (
+            <img
+              src={coverImageUrl}
+              alt="cover"
+              className="object-top mx-auto shadow-md rounded-sm"
+            />
+          ) : (
+            <CoverPlaceholder
+              book={book}
+              sizeClasses="w-[72px] h-[108px] xs:w-[96px] xs:h-[144px]"
+            />
+          )}
+        </Link>
+      </div>
+      <div className="grow">
+        <div className="text-2xl font-semibold">
+          {isRanked && <span className="mr-2">{rank}.</span>}
+          {title}
+        </div>
+        <div className="text-gray-300 text-lg">by {authorName}</div>
+        {note && (
+          <div className="my-2">
+            <CustomMarkdown markdown={note} />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/users/[username]/lists/[listSlug]/page.tsx
+++ b/src/app/users/[username]/lists/[listSlug]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation"
+import humps from "humps"
 import dayjs from "dayjs"
 import relativeTime from "dayjs/plugin/relativeTime"
 import prisma from "lib/prisma"
@@ -10,8 +11,9 @@ export const dynamic = "force-dynamic"
 
 dayjs.extend(relativeTime)
 
-export default async function UserListPage({ params }) {
+export default async function UserListPage({ params, searchParams }) {
   const { username, listSlug } = params
+  const { view } = humps.camelizeKeys(searchParams)
 
   const currentUserProfile = await getCurrentUserProfile()
 
@@ -49,6 +51,7 @@ export default async function UserListPage({ params }) {
       list={list}
       isUsersList={isUsersList}
       currentUserProfile={currentUserProfile}
+      view={view}
     />
   )
 }

--- a/src/app/users/[username]/lists/new/components/EditListBooks.tsx
+++ b/src/app/users/[username]/lists/new/components/EditListBooks.tsx
@@ -15,6 +15,9 @@ type Props = {
   onReorder: (reorderedIds: string[]) => void
   limit?: number
   isRanked: boolean
+  notesEnabled?: boolean
+  bookIdsToNotes?: any
+  onBookNoteChange?: (openLibraryWorkId: string, note: string) => void
 }
 
 export default function EditListBooks({
@@ -25,6 +28,9 @@ export default function EditListBooks({
   onReorder,
   limit,
   isRanked,
+  notesEnabled = false,
+  bookIdsToNotes = {},
+  onBookNoteChange = () => {},
 }: Props) {
   const [bookIds, setBookIds] = useState<string[]>([])
 
@@ -72,6 +78,9 @@ export default function EditListBooks({
                     onRemove={onBookRemove}
                     isRanked={isRanked}
                     rank={index + 1}
+                    notesEnabled={notesEnabled}
+                    note={bookIdsToNotes[book.openLibraryWorkId]}
+                    onNoteChange={onBookNoteChange}
                   />
                 ))}
               </ul>

--- a/src/app/users/[username]/lists/new/components/SortableBook.tsx
+++ b/src/app/users/[username]/lists/new/components/SortableBook.tsx
@@ -1,17 +1,39 @@
 "use client"
 
-import React from "react"
+import { useState, useEffect } from "react"
 import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
 import { GiOpenBook } from "react-icons/gi"
 import { BsXLg } from "react-icons/bs"
 import { RxDragHandleDots2 } from "react-icons/rx"
 import { truncateString } from "lib/helpers/general"
+import validations from "lib/constants/validations"
+import FormTextarea from "app/components/forms/FormTextarea"
 
-export default function SortableBook({ id, book, onRemove, isRanked, rank }) {
+export default function SortableBook({
+  id,
+  book,
+  onRemove,
+  isRanked,
+  rank,
+  notesEnabled = false,
+  note: _note,
+  onNoteChange,
+}) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id,
   })
+  const [note, setNote] = useState<string>(_note)
+  const [isEditingNote, setIsEditingNote] = useState<boolean>(false)
+
+  useEffect(() => {
+    setNote(_note)
+  }, [_note])
+
+  async function handleEditedNote(text) {
+    setIsEditingNote(false)
+    await onNoteChange(id, text)
+  }
 
   const style = {
     cursor: "default",
@@ -54,8 +76,37 @@ export default function SortableBook({ id, book, onRemove, isRanked, rank }) {
         )}
       </div>
       <div className="mx-4 grow">
-        <div className="mt-[-8px] font-bold">{truncateString(book.title, 64)}</div>
-        <div>{truncateString(book.authorName, 32)}</div>
+        {isEditingNote ? (
+          <EditNote
+            note={note}
+            onCancel={() => setIsEditingNote(false)}
+            onDone={handleEditedNote}
+          />
+        ) : (
+          <>
+            <div className="mt-[-8px] font-bold">{truncateString(book.title, 64)}</div>
+            <div>{truncateString(book.authorName, 32)}</div>
+            {notesEnabled &&
+              (note ? (
+                <div className="text-gray-300">
+                  {truncateString(note, 40)}
+                  <button
+                    onClick={() => setIsEditingNote(true)}
+                    className="ml-2 cat-btn-link text-sm text-gray-300"
+                  >
+                    edit
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setIsEditingNote(true)}
+                  className="cat-btn-link text-sm text-gray-300"
+                >
+                  add note
+                </button>
+              ))}
+          </>
+        )}
       </div>
       <div className="shrink-0">
         <button onClick={() => onRemove(book)} className="p-2">
@@ -63,5 +114,47 @@ export default function SortableBook({ id, book, onRemove, isRanked, rank }) {
         </button>
       </div>
     </li>
+  )
+}
+
+function EditNote({ note, onCancel, onDone }) {
+  const [text, setText] = useState<string>(note)
+  const [textErrorMsg, setTextErrorMsg] = useState<string>()
+
+  const { maxLength } = validations.list.bookNote
+
+  function handleDone() {
+    if (text && text.length > maxLength) {
+      setTextErrorMsg(`Note cannot be more than ${maxLength} characters.`)
+      return
+    }
+
+    const finalText = text === "" ? null : text
+
+    onDone(finalText)
+  }
+
+  return (
+    <>
+      <FormTextarea
+        name="text"
+        type="text"
+        rows={2}
+        remainingChars={maxLength - (text?.length || 0)}
+        errorMessage={textErrorMsg}
+        fullWidth
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        showFormattingReferenceTooltip={false}
+      />
+      <div className="flex justify-end">
+        <button className="mr-2 cat-btn cat-btn-sm cat-btn-white-outline" onClick={onCancel}>
+          cancel
+        </button>
+        <button className="cat-btn cat-btn-sm cat-btn-teal" onClick={handleDone}>
+          done
+        </button>
+      </div>
+    </>
   )
 }

--- a/src/lib/api/lists.ts
+++ b/src/lib/api/lists.ts
@@ -10,6 +10,7 @@ const createList = async (params, userProfile) => {
     slug: _listSlug,
     ranked: listRanked,
     designation,
+    bookNotes = [],
   } = params
 
   // find existing books
@@ -82,10 +83,16 @@ const createList = async (params, userProfile) => {
     return indexOfA - indexOfB
   })
 
+  const bookIdsToNotes = bookNotes.reduce((obj, item) => {
+    obj[item.openLibraryWorkId] = item.note
+    return obj
+  }, {})
+
   const listItemAssignments = orderedSelectedBookRecords.map((book, idx) => ({
     listedObjectType: "book",
     listedObjectId: book.id,
     sortOrder: idx + 1,
+    note: bookIdsToNotes[book.openLibraryWorkId!],
   }))
 
   const createdList = await prisma.list.create({
@@ -114,6 +121,7 @@ const updateList = async (list, params, userProfile) => {
     description: listDescription,
     ranked: listRanked,
     books: selectedBooks,
+    bookNotes = [],
   } = params
 
   // find existing books
@@ -208,11 +216,17 @@ const updateList = async (list, params, userProfile) => {
     return indexOfA - indexOfB
   })
 
+  const bookIdsToNotes = bookNotes.reduce((obj, item) => {
+    obj[item.openLibraryWorkId] = item.note
+    return obj
+  }, {})
+
   const listItemAssignments = orderedSelectedBookRecords.map((book, idx) => ({
     listId: list.id,
     listedObjectType: "book",
     listedObjectId: book.id,
     sortOrder: idx + 1,
+    note: bookIdsToNotes[book.openLibraryWorkId!],
   }))
 
   await prisma.listItemAssignment.createMany({

--- a/src/lib/constants/validations.ts
+++ b/src/lib/constants/validations.ts
@@ -12,6 +12,11 @@ const validations = {
       maxLength: 100,
     },
   },
+  list: {
+    bookNote: {
+      maxLength: 300,
+    },
+  },
   userCurrentStatus: {
     text: {
       maxLength: 300,


### PR DESCRIPTION
+ when creating/editing a list, you can optionally add a note on each book.
+ on list page, you can toggle between grid view (which was the existing view) and the new "card" view, which shows title/author and notes as well. this also syncs with a query param `view` on the page url, so you can link directly to a view.

https://app.asana.com/0/1205114589319956/1205456044796784
https://app.asana.com/0/1205114589319956/1205891924459521