### PR TITLE
feature flags (for requiring invite code)

### DIFF
--- a/prisma/migrations/20231219065334_create_feature_flags/migration.sql
+++ b/prisma/migrations/20231219065334_create_feature_flags/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "feature_flags" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "name" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT false,
+    "scope" TEXT,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6),
+
+    CONSTRAINT "feature_flags_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "feature_flags_name_scope_key" ON "feature_flags"("name", "scope");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -242,3 +242,15 @@ model UserInvite {
   @@index([inviterId])
   @@map("user_invites")
 }
+
+model FeatureFlag {
+  id        String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name      String    @map("name")
+  enabled   Boolean   @default(false) @map("enabled")
+  scope     String?   @map("scope")
+  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime? @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  @@unique([name, scope])
+  @@map("feature_flags")
+}

--- a/src/app/api/auth/sign-up/route.ts
+++ b/src/app/api/auth/sign-up/route.ts
@@ -3,6 +3,7 @@ import humps from "humps"
 import { createClient as createSupabaseClient } from "@supabase/supabase-js"
 import prisma from "lib/prisma"
 import { withApiHandling } from "lib/api/withApiHandling"
+import FeatureFlag from "enums/FeatureFlag"
 import type { NextRequest } from "next/server"
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
@@ -19,23 +20,32 @@ export const POST = withApiHandling(
     const { reqJson } = params
     const { email, username, password, inviteCode } = reqJson
 
-    // validate invite code
-    if (!inviteCode) {
-      return NextResponse.json({ error: "Invite code is required." }, { status: 400 })
-    }
-
-    const matchingInvite = await prisma.userInvite.findFirst({
+    let matchingInvite
+    const invitesFeatureFlag = await prisma.featureFlag.findFirst({
       where: {
-        code: inviteCode,
+        name: FeatureFlag.RequireInvites,
       },
     })
 
-    if (!matchingInvite) {
-      return NextResponse.json({ error: "Invite code is invalid." }, { status: 400 })
-    }
+    if (invitesFeatureFlag?.enabled) {
+      // validate invite code
+      if (!inviteCode) {
+        return NextResponse.json({ error: "Invite code is required." }, { status: 400 })
+      }
 
-    if (matchingInvite.claimedAt) {
-      return NextResponse.json({ error: "Invite has already been claimed." }, { status: 400 })
+      matchingInvite = await prisma.userInvite.findFirst({
+        where: {
+          code: inviteCode,
+        },
+      })
+
+      if (!matchingInvite) {
+        return NextResponse.json({ error: "Invite code is invalid." }, { status: 400 })
+      }
+
+      if (matchingInvite.claimedAt) {
+        return NextResponse.json({ error: "Invite has already been claimed." }, { status: 400 })
+      }
     }
 
     // validations
@@ -135,16 +145,18 @@ export const POST = withApiHandling(
 
     console.log(createUserRes)
 
-    // claim invite
-    await prisma.userInvite.update({
-      where: {
-        id: matchingInvite.id,
-      },
-      data: {
-        claimedAt: new Date(),
-        claimedByUserId: createUserRes.id,
-      },
-    })
+    if (invitesFeatureFlag?.enabled) {
+      // claim invite
+      await prisma.userInvite.update({
+        where: {
+          id: matchingInvite.id,
+        },
+        data: {
+          claimedAt: new Date(),
+          claimedByUserId: createUserRes.id,
+        },
+      })
+    }
 
     // seed book lists
     const startingLists = [

--- a/src/enums/FeatureFlag.ts
+++ b/src/enums/FeatureFlag.ts
@@ -1,0 +1,5 @@
+enum FeatureFlag {
+  RequireInvites = "require_invites",
+}
+
+export default FeatureFlag

--- a/src/enums/FeatureFlagScope.ts
+++ b/src/enums/FeatureFlagScope.ts
@@ -1,0 +1,5 @@
+enum FeatureFlagScope {
+  Global = "global",
+}
+
+export default FeatureFlagScope


### PR DESCRIPTION
in PR #51 I made all user signups require an invite code, and made all invite codes require an inviting user, thereby making it impossible to create the first user on the fresh prod db (which has neither users nor invites), like a dum-dum.

but this gave me an excuse to implement feature flags, which I'd been meaning to do, anyway. this way we can toggle the "require invites" logic on/off easily from the db. so I can deploy this PR, let myself sign up as the first user, then enable "require invites" for everyone else, without another code change.

https://app.asana.com/0/1205114589319956/1205982125618887