### PR TITLE
Fix ListBook rank line location

### DIFF
--- a/src/app/lists/components/ListBook.tsx
+++ b/src/app/lists/components/ListBook.tsx
@@ -37,11 +37,11 @@ export default function ListBook({ book, isFavorite = false, isRanked = false, r
 
   return (
     <div key={book.id} className="flex flex-col items-center justify-center">
-      <Link href={getBookLink(book.slug)}>
+      <Link href={getBookLink(book.slug)} className="grow flex items-center">
         <button
           className={`${
             isFavorite ? favoriteBookWidths : defaultWidths
-          } h-auto my-8 mx-auto sm:my-4 grow`}
+          } h-auto my-8 mx-auto sm:my-4`}
           disabled={isMobile}
         >
           <div>


### PR DESCRIPTION
Looks like the main issue is that we were using `grow` on a button to push down the rank number and that button was placed inside of another element. Just need to move the `grow` to the containing element 🙂  Also centering the images too.