### PR TITLE
multi-use (30-day expiring) invites

### DIFF
--- a/prisma/migrations/20240106042459_create_user_invite_claims/migration.sql
+++ b/prisma/migrations/20240106042459_create_user_invite_claims/migration.sql
@@ -1,0 +1,25 @@
+-- AlterTable
+ALTER TABLE "user_invites" ADD COLUMN     "expires_at" TIMESTAMPTZ(6);
+
+-- CreateTable
+CREATE TABLE "user_invite_claims" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "invite_id" UUID NOT NULL,
+    "claimed_by_user_id" UUID NOT NULL,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6),
+
+    CONSTRAINT "user_invite_claims_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "user_invite_claims_invite_id_idx" ON "user_invite_claims"("invite_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_invite_claims_claimed_by_user_id_key" ON "user_invite_claims"("claimed_by_user_id");
+
+-- AddForeignKey
+ALTER TABLE "user_invite_claims" ADD CONSTRAINT "user_invite_claims_invite_id_fkey" FOREIGN KEY ("invite_id") REFERENCES "user_invites"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_invite_claims" ADD CONSTRAINT "user_invite_claims_claimed_by_user_id_fkey" FOREIGN KEY ("claimed_by_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,12 +34,13 @@ model UserProfile {
 }
 
 model User {
-  id            String       @id @db.Uuid
-  email         String       @unique
-  createdAt     DateTime     @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt     DateTime?    @updatedAt @map("updated_at") @db.Timestamptz(6)
+  id            String           @id @db.Uuid
+  email         String           @unique
+  createdAt     DateTime         @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt     DateTime?        @updatedAt @map("updated_at") @db.Timestamptz(6)
   profile       UserProfile?
   inviteClaimed UserInvite?
+  inviteClaim   UserInviteClaim?
 
   @@map("users")
 }
@@ -229,20 +230,36 @@ model UserRole {
 }
 
 model UserInvite {
-  id              String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  inviterId       String      @map("inviter_id") @db.Uuid
-  code            String      @map("code")
-  claimedByUserId String?     @map("claimed_by_user_id") @db.Uuid
-  claimedAt       DateTime?   @map("claimed_at") @db.Timestamptz(6)
-  createdAt       DateTime    @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt       DateTime?   @updatedAt @map("updated_at") @db.Timestamptz(6)
-  inviter         UserProfile @relation(fields: [inviterId], references: [id])
-  claimedByUser   User?       @relation(fields: [claimedByUserId], references: [id])
+  id              String            @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  inviterId       String            @map("inviter_id") @db.Uuid
+  code            String            @map("code")
+  expiresAt       DateTime?         @map("expires_at") @db.Timestamptz(6)
+  claimedByUserId String?           @map("claimed_by_user_id") @db.Uuid
+  claimedAt       DateTime?         @map("claimed_at") @db.Timestamptz(6)
+  createdAt       DateTime          @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt       DateTime?         @updatedAt @map("updated_at") @db.Timestamptz(6)
+  inviter         UserProfile       @relation(fields: [inviterId], references: [id])
+  claimedByUser   User?             @relation(fields: [claimedByUserId], references: [id])
+  claims          UserInviteClaim[]
 
   @@unique([code])
   @@unique([claimedByUserId])
   @@index([inviterId])
   @@map("user_invites")
+}
+
+model UserInviteClaim {
+  id              String     @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  inviteId        String     @map("invite_id") @db.Uuid
+  claimedByUserId String     @map("claimed_by_user_id") @db.Uuid
+  createdAt       DateTime   @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt       DateTime?  @updatedAt @map("updated_at") @db.Timestamptz(6)
+  invite          UserInvite @relation(fields: [inviteId], references: [id])
+  claimedByUser   User       @relation(fields: [claimedByUserId], references: [id])
+
+  @@unique([claimedByUserId])
+  @@index([inviteId])
+  @@map("user_invite_claims")
 }
 
 model FeatureFlag {

--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -31,14 +31,21 @@ export default async function SignUpPage({ searchParams }) {
       where: {
         code: inviteCode,
       },
+      include: {
+        claims: true,
+      },
     })
 
     if (!invite) {
       return <ErrorPage errorMessage="Invalid invite code." />
     }
 
-    if (invite.claimedAt) {
+    if (!invite.expiresAt && invite.claims.length > 0) {
       return <ErrorPage errorMessage="This invite has already been claimed." />
+    }
+
+    if (invite.expiresAt && invite.expiresAt < new Date()) {
+      return <ErrorPage errorMessage="This invite has expired." />
     }
   }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -90,9 +90,10 @@ const api = {
   },
   invites: {
     get: () => fetchJson(`/api/user_invites`),
-    create: () =>
+    create: (requestData) =>
       fetchJson(`/api/user_invites`, {
         method: "POST",
+        body: prepReqBody(requestData),
       }),
   },
   likes: {


### PR DESCRIPTION
invites can be either single-use (never expiring) OR unlimited use (30-day expiring). we can support other options/combinations later too, but not really sure what else is needed so just gonna keep it simple for now.

all invites are claimed via creating a `user_invite_claim` record; the single-use claim-related columns on `user_invites` are now deprecated.

https://app.asana.com/0/1205114589319956/1206276222083142