### PR TITLE
news-related cleanup and enhancements

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -13,6 +13,12 @@ if (env !== "development") {
     release: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
     normalizeDepth: 5,
 
+    ignoreErrors: [
+      "ResizeObserver loop completed with undelivered notifications.",
+      "Failed to fetch",
+      "network error",
+    ],
+
     // Adjust this value in production, or use tracesSampler for greater control
     tracesSampleRate: 1,
 

--- a/src/app/news/[postSlug]/page.tsx
+++ b/src/app/news/[postSlug]/page.tsx
@@ -1,17 +1,36 @@
+import { redirect } from "next/navigation"
 import Link from "next/link"
 import humps from "humps"
+import dayjs from "dayjs"
 import * as ghost from "lib/ghost"
+import { getMetadata } from "lib/server/metadata"
+import { dateTimeFormats } from "lib/constants/dateTime"
+import type { Metadata } from "next"
+
+export async function generateMetadata({ params }): Promise<Metadata> {
+  return getMetadata({
+    key: "news.post",
+    params,
+  })
+}
 
 export default async function CatalogNewsPostPage({ params }) {
   const { postSlug } = params
   let post = await ghost.getPost(postSlug)
 
+  if (!post) redirect("/news")
+
   post = humps.camelizeKeys(post)
+
+  const { longAmericanDate } = dateTimeFormats
+  const publishDate = dayjs(post.publishedAt).format(longAmericanDate).toLowerCase()
 
   return (
     <div className="px-8 py-12 max-w-2xl mx-auto">
       <div className="text-2xl font-bold font-mulish">{post.title}</div>
-      <div className="mt-2 text-gray-300">by {post.primaryAuthor.name}</div>
+      <div className="mt-2 text-gray-300">
+        by {post.primaryAuthor.name} • {publishDate}
+      </div>
       <div className="cat-news-post my-12" dangerouslySetInnerHTML={{ __html: post.html }} />
       <div className="mt-12">
         <Link href="/news" className="cat-underline font-mulish">

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,13 +1,25 @@
 import Link from "next/link"
 import humps from "humps"
 import { FaRss } from "react-icons/fa"
+import dayjs from "dayjs"
 import * as ghost from "lib/ghost"
 import { truncateString } from "lib/helpers/general"
+import { dateTimeFormats } from "lib/constants/dateTime"
 import GhostSubscribe from "app/components/GhostSubscribe"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "news • catalog",
+  openGraph: {
+    title: "news • catalog",
+  },
+}
 
 export default async function CatalogNewsHome() {
   let posts = await ghost.getAllPosts()
   posts = humps.camelizeKeys(posts)
+
+  const { longAmericanDate } = dateTimeFormats
 
   return (
     <div className="px-8 py-12 max-w-2xl mx-auto">
@@ -18,17 +30,22 @@ export default async function CatalogNewsHome() {
         </Link>
       </div>
       <hr className="my-1 h-[1px] border-none bg-gray-300" />
-      {posts.map((post) => (
-        <div key={post.id} className="py-8 border-b border-b-gray-500 last:border-none">
-          <div className="text-2xl font-semibold font-mulish">
-            <Link href={`/news/${post.slug}`} className="cat-underline">
-              {post.title}
-            </Link>
+      {posts.map((post) => {
+        const publishDate = dayjs(post.publishedAt).format(longAmericanDate).toLowerCase()
+        return (
+          <div key={post.id} className="py-8 border-b border-b-gray-500 last:border-none">
+            <div className="text-2xl font-semibold font-mulish">
+              <Link href={`/news/${post.slug}`} className="cat-underline">
+                {post.title}
+              </Link>
+            </div>
+            <div className="mt-2 text-gray-300 font-mulish">
+              by {post.primaryAuthor.name} • {publishDate}
+            </div>
+            <div className="mt-2">{truncateString(post.excerpt, 200)}</div>
           </div>
-          <div className="mt-2 text-gray-300 font-mulish">by {post.primaryAuthor.name}</div>
-          <div className="mt-2">{truncateString(post.excerpt, 200)}</div>
-        </div>
-      ))}
+        )
+      })}
 
       <div className="mt-24">
         <GhostSubscribe />

--- a/src/lib/ghost.ts
+++ b/src/lib/ghost.ts
@@ -15,11 +15,19 @@ async function getAllPosts() {
 }
 
 async function getPost(slug: string) {
-  const post = await api.posts.read(
-    { slug },
-    { include: "authors", formats: ["html", "plaintext"] },
-  )
-  return post
+  try {
+    const post = await api.posts.read(
+      { slug },
+      { include: "authors", formats: ["html", "plaintext"] },
+    )
+    return post
+  } catch (error: any) {
+    const ERRORS_TO_IGNORE = [/ValidationError/, /NotFoundError/]
+
+    if (ERRORS_TO_IGNORE.some((e) => error.message.match(e))) {
+      return null
+    }
+  }
 }
 
 export { getAllPosts, getPost }

--- a/src/lib/server/metadata.ts
+++ b/src/lib/server/metadata.ts
@@ -1,5 +1,6 @@
 import prisma from "lib/prisma"
 import { reportToSentry } from "lib/sentry"
+import * as ghost from "lib/ghost"
 import { getCurrentUserProfile } from "lib/server/auth"
 import UserProfile from "lib/models/UserProfile"
 import UserRole from "enums/UserRole"
@@ -48,10 +49,13 @@ const METADATA_CONFIG = {
   "admin.invites": {
     title: () => "admin • invites • catalog",
   },
+  "news.post": {
+    title: (title) => `${title} • news • catalog`,
+  },
 }
 
 async function getMetadata({ key, params }): Promise<Metadata> {
-  const { username, bookSlug, listSlug, shelf } = params
+  const { username, bookSlug, listSlug, shelf, postSlug } = params
 
   const config = METADATA_CONFIG[key]
 
@@ -126,6 +130,12 @@ async function getMetadata({ key, params }): Promise<Metadata> {
       if (!isAdmin) return {}
 
       pageTitle = config.title()
+    } else if (key === "news.post" && postSlug) {
+      const post = await ghost.getPost(postSlug)
+
+      if (!post) return {}
+
+      pageTitle = config.title(post.title)
     }
 
     return {


### PR DESCRIPTION
+ ignore some sentry errors we can't do anything about
+ intercept ghost post api errors and redirect to news index page
+ page metadata for news index + news post pages
+ show timestamps on news pages

https://app.asana.com/0/1205114589319956/1206201025837384