### PR TITLE
upload cover images to supabase, pt 3

### DIFF
--- a/src/app/api/books/process_cover_images/route.ts
+++ b/src/app/api/books/process_cover_images/route.ts
@@ -1,0 +1,140 @@
+import { NextResponse } from "next/server"
+import prisma from "lib/prisma"
+import OpenLibrary from "lib/openLibrary"
+import { uploadCoverImage } from "lib/server/supabaseStorage"
+import { fetchImageAsBlob } from "lib/helpers/general"
+import { withApiHandling } from "lib/api/withApiHandling"
+import { reportToSentry } from "lib/sentry"
+import type { NextRequest } from "next/server"
+
+const BOOKS_LIMIT = 30
+
+export const GET = withApiHandling(
+  async (req: NextRequest) => {
+    if (req.headers.get("Authorization") !== `Bearer ${process.env.CRON_SECRET}`) {
+      return NextResponse.json({ error: "Unauthorized " }, { status: 401 })
+    }
+
+    let successCount = 0
+    const failures: any[] = []
+
+    const totalBooksToProcess = await prisma.book.count({
+      where: {
+        coverImageUrl: {
+          not: null,
+        },
+        coverImageThumbnailUrl: null,
+      },
+    })
+
+    if (totalBooksToProcess > BOOKS_LIMIT) {
+      reportToSentry(
+        `api.books.process_cover_images: found ${totalBooksToProcess} with cover images to process, but only processing ${BOOKS_LIMIT}.`,
+      )
+    }
+
+    // fetch a batch of books with covers that haven't been processed
+    const allBooks = await prisma.book.findMany({
+      where: {
+        coverImageUrl: {
+          not: null,
+        },
+        coverImageThumbnailUrl: null,
+      },
+      orderBy: {
+        createdAt: "asc",
+      },
+      take: BOOKS_LIMIT,
+    })
+
+    console.log(
+      `api.books.process_cover_images: found ${allBooks.length} books with cover images in this batch.`,
+    )
+
+    // for each book, fetch cover images, upload to supabase, and update book record
+    for (const book of allBooks) {
+      const { coverImageUrl, slug, id } = book
+
+      const { md: olThumbnailUrl, lg: olLargeUrl } = OpenLibrary.getCoverUrlsBySize(
+        coverImageUrl!,
+      ) as any
+
+      const baseOptions = {
+        bookId: id,
+        bookSlug: slug,
+        extension: coverImageUrl!.split(".").pop(),
+      }
+
+      try {
+        console.log(`api.books.process_cover_images: starting ${slug}...`)
+        console.log(`api.books.process_cover_images: ${slug}: fetching large image...`)
+
+        const { blob: largeBlob, mimeType: largeMimeType } = await fetchImageAsBlob(olLargeUrl)
+
+        console.log(`api.books.process_cover_images: ${slug}: large image fetched. uploading...`)
+
+        const largeOptions = {
+          ...baseOptions,
+          size: "lg",
+          mimeType: largeMimeType,
+        }
+
+        const largeUrl = await uploadCoverImage(largeBlob, largeOptions)
+
+        console.log(
+          `api.books.process_cover_images: ${slug}: large image uploaded. fetching thumbnail image...`,
+        )
+
+        const { blob: thumbnailBlob, mimeType: thumbnailMimeType } = await fetchImageAsBlob(
+          olThumbnailUrl,
+        )
+
+        console.log(
+          `api.books.process_cover_images: ${slug}: thumbnail image fetched. uploading...`,
+        )
+
+        const thumbnailOptions = {
+          ...baseOptions,
+          size: "md",
+          mimeType: thumbnailMimeType,
+        }
+
+        const thumbnailUrl = await uploadCoverImage(thumbnailBlob, thumbnailOptions)
+
+        console.log(
+          `api.books.process_cover_images: ${slug}: thumbnail image uploaded. updating book...`,
+        )
+
+        await prisma.book.update({
+          where: {
+            id,
+          },
+          data: {
+            coverImageUrl: largeUrl,
+            coverImageThumbnailUrl: thumbnailUrl,
+            openLibraryCoverImageUrl: coverImageUrl,
+          },
+        })
+
+        console.log(`api.books.process_cover_images: ${slug} updated.`)
+
+        successCount += 1
+      } catch (error: any) {
+        reportToSentry(error, { slug, coverImageUrl })
+        failures.push({ slug, error, errorMsg: error.message })
+      }
+    }
+
+    console.log(`${successCount} books updated.`)
+    console.log("failures:")
+    console.log(failures)
+    console.log(`${failures.length} failures.`)
+
+    return NextResponse.json({}, { status: 200 })
+  },
+  {
+    requireSession: false,
+    requireUserProfile: false,
+    requireJsonBody: false,
+  },
+)

--- a/src/app/components/nav/Search.tsx
+++ b/src/app/components/nav/Search.tsx
@@ -216,9 +216,9 @@ export default function Search({
                                 active && "bg-gray-700"
                               } px-2 py-3 cursor-pointer border-b border-b-gray-700 last:border-none`}
                             >
-                              {book.coverImageThumbnailUrl ? (
+                              {book.coverImageThumbnailUrl || book.coverImageUrl ? (
                                 <img
-                                  src={book.coverImageThumbnailUrl}
+                                  src={book.coverImageThumbnailUrl || book.coverImageUrl}
                                   className="w-16 h-auto shrink-0 rounded-sm"
                                   alt={`${book.title} cover`}
                                 />

--- a/src/app/lists/components/AddBookToListsModal.tsx
+++ b/src/app/lists/components/AddBookToListsModal.tsx
@@ -19,7 +19,8 @@ export default function AddBookToListsModal({ book, userLists, onClose, isOpen }
   const [selectedLists, setSelectedLists] = useState<List[]>([])
   const [isBusy, setIsBusy] = useState<boolean>(false)
 
-  const listsStr = `add to ${selectedLists.length} ${selectedLists.length === 1 ? "list" : "lists"}`
+  const listsStr = `${selectedLists.length} ${selectedLists.length === 1 ? "list" : "lists"}`
+  const buttonCopy = `add to ${listsStr}`
 
   const toggleSelected = (list) => {
     if (isSelected(list)) {
@@ -114,7 +115,7 @@ export default function AddBookToListsModal({ book, userLists, onClose, isOpen }
               disabled={isBusy || selectedLists.length === 0}
               className="cat-btn cat-btn-sm cat-btn-gold ml-4"
             >
-              {selectedLists.length === 0 ? "add" : listsStr}
+              {selectedLists.length === 0 ? "add" : buttonCopy}
             </button>
           </div>
         </Dialog.Panel>

--- a/src/lib/api/books.ts
+++ b/src/lib/api/books.ts
@@ -90,7 +90,10 @@ async function findOrCreateBook(_book: Book) {
         },
       })
     } catch (error) {
-      reportToSentry(error, { coverImageUrl })
+      reportToSentry(error, {
+        bookId: createdBook.id,
+        coverImageUrl,
+      })
     }
   }
 

--- a/src/lib/api/lists.ts
+++ b/src/lib/api/lists.ts
@@ -1,6 +1,7 @@
 import prisma from "lib/prisma"
 import { reportToSentry } from "lib/sentry"
 import { generateUniqueSlug, runInSequence } from "lib/helpers/general"
+import { findOrCreateBook } from "lib/api/books"
 import { findOrCreateLike } from "lib/api/likes"
 import ListDesignation from "enums/ListDesignation"
 import InteractionObjectType from "enums/InteractionObjectType"
@@ -34,6 +35,8 @@ const createList = async (params, userProfile) => {
       title,
       authorName,
       coverImageUrl,
+      coverImageThumbnailUrl,
+      openLibraryCoverImageUrl,
       openLibraryWorkId,
       editionsCount,
       firstPublishedYear,
@@ -46,6 +49,8 @@ const createList = async (params, userProfile) => {
       title,
       authorName,
       coverImageUrl,
+      coverImageThumbnailUrl,
+      openLibraryCoverImageUrl,
       openLibraryWorkId,
       editionsCount,
       firstPublishedYear: Number(firstPublishedYear),
@@ -145,6 +150,8 @@ const updateList = async (list, params, userProfile) => {
       title,
       authorName,
       coverImageUrl,
+      coverImageThumbnailUrl,
+      openLibraryCoverImageUrl,
       openLibraryWorkId,
       editionsCount,
       firstPublishedYear,
@@ -157,6 +164,8 @@ const updateList = async (list, params, userProfile) => {
       title,
       authorName,
       coverImageUrl,
+      coverImageThumbnailUrl,
+      openLibraryCoverImageUrl,
       openLibraryWorkId,
       editionsCount,
       firstPublishedYear: Number(firstPublishedYear),
@@ -313,6 +322,8 @@ const addBook = async (book, list) => {
       subtitle,
       description,
       coverImageUrl,
+      coverImageThumbnailUrl,
+      openLibraryCoverImageUrl,
       openLibraryWorkId,
       editionsCount,
       firstPublishedYear,
@@ -327,6 +338,8 @@ const addBook = async (book, list) => {
       subtitle,
       description,
       coverImageUrl,
+      coverImageThumbnailUrl,
+      openLibraryCoverImageUrl,
       openLibraryWorkId,
       editionsCount,
       firstPublishedYear: Number(firstPublishedYear),
@@ -334,9 +347,7 @@ const addBook = async (book, list) => {
       originalTitle,
     }
 
-    persistedBook = await prisma.book.create({
-      data: bookData,
-    })
+    persistedBook = await findOrCreateBook(bookData)
   }
 
   const existingListItemAssignments = await prisma.listItemAssignment.findMany({

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/books/process_cover_images",
+      "schedule": "0 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
in #69 I forgot to look at ALL places where books get created. when creating/updating lists, books are created in a batch; however, supabase doesn't allow batched file uploads. so it would be too slow to try to process the cover image for each book one by one while the user is waiting for a response. but it's not necessary because the processing is just an optimization. we can use the OL cover image url right away, then run a cron job that pings an endpoint to process N books at a time. (I've set it to 30 books at a time, once an hour, which is more than enough for our current needs, but can be easily tweaked as well.)

this approach should work until there are so many books to process that it exceeds something like
```
number of books that can be processed within the 60s vercel timeout x number of minutes in a day (1440)
```
(which would be like 50-100k books/day?)

other small things:
+ use `findOrCreateBook` when adding 1 book to a list, too - neglected in #69 
+ save thumbnail url if already available (ie from openlibrary)
+ in search results, fall back to large cover img if no thumbnail available
+ fix "add book to list" toast copy

https://app.asana.com/0/1205114589319956/1206284771545275
