### PR TITLE
increase vercel function timeout to 300s

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,10 @@
       "path": "/api/books/process_cover_images",
       "schedule": "0 * * * *"
     }
-  ]
+  ],
+  "functions": {
+    "app/api/**/route.ts": {
+      "maxDuration": 300
+    }
+  }
 }


### PR DESCRIPTION
TIL instead of always being 60s, the vercel timeout now defaults to 15s but is configurable to be up to 300s. so let's make it higher.

https://vercel.com/docs/functions/serverless-functions/runtimes#max-duration
https://vercel.com/docs/functions/configuring-functions/duration