### PR TITLE
notifs for follows and likes

### DIFF
--- a/prisma/migrations/20240116053035_create_notifications/migration.sql
+++ b/prisma/migrations/20240116053035_create_notifications/migration.sql
@@ -1,0 +1,32 @@
+-- CreateTable
+CREATE TABLE "notifications" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "agent_id" UUID NOT NULL,
+    "agent_type" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "object_id" UUID NOT NULL,
+    "object_type" TEXT NOT NULL,
+    "source_id" UUID,
+    "source_type" TEXT,
+    "notified_user_profile_id" UUID NOT NULL,
+    "read" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6),
+
+    CONSTRAINT "notifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "notifications_agent_id_agent_type_idx" ON "notifications"("agent_id", "agent_type");
+
+-- CreateIndex
+CREATE INDEX "notifications_object_id_object_type_idx" ON "notifications"("object_id", "object_type");
+
+-- CreateIndex
+CREATE INDEX "notifications_source_id_source_type_idx" ON "notifications"("source_id", "source_type");
+
+-- CreateIndex
+CREATE INDEX "notifications_notified_user_profile_id_idx" ON "notifications"("notified_user_profile_id");
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_notified_user_profile_id_fkey" FOREIGN KEY ("notified_user_profile_id") REFERENCES "user_profiles"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,7 @@ model UserProfile {
   roleAssignments      UserRole[]
   invitesCreated       UserInvite[]
   config               UserConfig?
+  notifications        Notification[]
 
   @@index([nameSearch], type: Gin)
   @@map("user_profiles")
@@ -333,4 +334,26 @@ model UserConfig {
 
   @@unique([userProfileId])
   @@map("user_configs")
+}
+
+model Notification {
+  id                    String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  agentId               String      @map("agent_id") @db.Uuid
+  agentType             String      @map("agent_type")
+  type                  String      @map("type")
+  objectId              String      @map("object_id") @db.Uuid
+  objectType            String      @map("object_type")
+  sourceId              String?     @map("source_id") @db.Uuid
+  sourceType            String?     @map("source_type")
+  notifiedUserProfileId String      @map("notified_user_profile_id") @db.Uuid
+  read                  Boolean     @default(false)
+  createdAt             DateTime    @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt             DateTime?   @updatedAt @map("updated_at") @db.Timestamptz(6)
+  notifiedUser          UserProfile @relation(fields: [notifiedUserProfileId], references: [id], onDelete: Cascade)
+
+  @@index([agentId, agentType])
+  @@index([objectId, objectType])
+  @@index([sourceId, sourceType])
+  @@index([notifiedUserProfileId])
+  @@map("notifications")
 }

--- a/src/app/components/CustomMarkdown.tsx
+++ b/src/app/components/CustomMarkdown.tsx
@@ -52,12 +52,12 @@ const components: Components = {
 
 const plugins = [linkifyRegex(/(?:https?):\/\/\S+/g)]
 
-const CustomMarkdown = ({ markdown, componentOverrides = {} }) => {
+const CustomMarkdown = ({ markdown, componentOverrides = {}, moreClasses = "" }) => {
   const finalComponents = { ...components, ...componentOverrides }
 
   return (
     <Markdown
-      className="whitespace-pre-wrap break-words"
+      className={`whitespace-pre-wrap break-words ${moreClasses}`}
       components={finalComponents}
       remarkPlugins={plugins}
     >

--- a/src/app/components/nav/UserNav.tsx
+++ b/src/app/components/nav/UserNav.tsx
@@ -49,6 +49,7 @@ export default function UserNav({ currentUserProfile: _initialCurrentUserProfile
   const { username } = currentUserProfile || {}
 
   const userLinks = [
+    { name: "notifs", path: "/home/notifs" },
     { name: "profile", path: getUserProfileLink(username) },
     { name: "shelves", path: getUserShelvesLink(username) },
     { name: "lists", path: getUserListsLink(username) },

--- a/src/app/components/notifs/NotifCard.tsx
+++ b/src/app/components/notifs/NotifCard.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import Link from "next/link"
+import CustomMarkdown from "app/components/CustomMarkdown"
+import { getUserProfileLink, getListLink, truncateString } from "lib/helpers/general"
+import { getFormattedTimestamps } from "lib/helpers/dateTime"
+import UserProfile from "lib/models/UserProfile"
+import NotificationType from "enums/NotificationType"
+import NotificationObjectType from "enums/NotificationObjectType"
+import BookNoteType from "enums/BookNoteType"
+
+const TEXT_TRUNCATE_LENGTH = 60
+
+export default function NotifCard({ notif, currentUserProfile }) {
+  const { id, type, agent: _agent, objectType, object, createdAt } = notif
+
+  const agent = UserProfile.build(_agent)
+
+  const timestampTooltipAnchorId = `comment-created-at-${id}`
+
+  let createdAtFromNow
+  let timestampTooltip
+  if (createdAt) {
+    ;({ fromNow: createdAtFromNow, tooltip: timestampTooltip } = getFormattedTimestamps(
+      createdAt,
+      timestampTooltipAnchorId,
+    ))
+  }
+
+  return (
+    <div className="px-2 py-4 text-gray-300 border-b-[1px] border-b-gray-800 last:border-none">
+      {type === NotificationType.Follow && (
+        <>
+          <AgentLink agent={agent} /> followed you.
+        </>
+      )}
+
+      {type === NotificationType.Like && (
+        <>
+          <AgentLink agent={agent} /> liked your{" "}
+          <ObjectText
+            object={object}
+            objectType={objectType}
+            currentUserProfile={currentUserProfile}
+          />
+          .
+        </>
+      )}
+      <span id={timestampTooltipAnchorId} className="xs:ml-2 xs:mt-2 text-sm text-gray-500">
+        {createdAtFromNow}
+      </span>
+      {timestampTooltip}
+    </div>
+  )
+}
+
+function AgentLink({ agent }) {
+  return (
+    <Link href={getUserProfileLink(agent.username)} className="cat-btn-link text-white">
+      {agent.name}
+    </Link>
+  )
+}
+
+// when quoting object's text, render paragraphs as inline
+const componentOverrides = {
+  p: ({ children }) => children,
+}
+
+function ObjectText({ object, objectType: _objectType, currentUserProfile }) {
+  let objectType = _objectType
+  if (objectType === NotificationObjectType.BookNote) {
+    objectType = object.noteType === BookNoteType.JournalEntry ? "note" : "post"
+  }
+
+  const _text = object.title || object.text
+  const text = truncateString(_text, TEXT_TRUNCATE_LENGTH)
+
+  if (objectType === NotificationObjectType.List && object.creatorId === currentUserProfile.id) {
+    return (
+      <>
+        {objectType}{" "}
+        <Link
+          href={getListLink(currentUserProfile, object.slug)}
+          className="cat-btn-link text-white"
+        >
+          {text}
+        </Link>
+      </>
+    )
+  } else {
+    return (
+      <>
+        {objectType}{" "}
+        <div className="inline text-white">
+          <CustomMarkdown
+            markdown={text}
+            componentOverrides={componentOverrides}
+            moreClasses="inline"
+          />
+        </div>
+      </>
+    )
+  }
+}

--- a/src/app/home/(homePages)/notifs/page.tsx
+++ b/src/app/home/(homePages)/notifs/page.tsx
@@ -1,0 +1,48 @@
+import prisma from "lib/prisma"
+import { getCurrentUserProfile } from "lib/server/auth"
+import { decorateNotifs } from "lib/server/decorators"
+import NotifCard from "app/components/notifs/NotifCard"
+import EmptyState from "app/components/EmptyState"
+import type { Metadata } from "next"
+
+export const dynamic = "force-dynamic"
+
+export const metadata: Metadata = {
+  title: "notifs • catalog",
+  openGraph: {
+    title: "notifs • catalog",
+  },
+}
+
+const NOTIFS_LIMIT = 50
+
+export default async function NotifsPage() {
+  const currentUserProfile = await getCurrentUserProfile()
+
+  let notifs = await prisma.notification.findMany({
+    where: {
+      agentId: {
+        not: currentUserProfile.id,
+      },
+      notifiedUserProfileId: currentUserProfile.id,
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+    take: NOTIFS_LIMIT,
+  })
+
+  notifs = await decorateNotifs(notifs)
+
+  return (
+    <div className="max-w-xl mx-auto font-mulish">
+      {notifs.length > 0 ? (
+        notifs.map((notif) => (
+          <NotifCard key={notif.id} notif={notif} currentUserProfile={currentUserProfile} />
+        ))
+      ) : (
+        <EmptyState text="You don't have any notifications." />
+      )}
+    </div>
+  )
+}

--- a/src/app/home/components/HomeTabs.tsx
+++ b/src/app/home/components/HomeTabs.tsx
@@ -16,16 +16,16 @@ export default function HomeTabs() {
       href: "/home",
     },
     {
+      name: "notifs",
+      href: "/home/notifs",
+    },
+    {
       name: "recent lists",
       href: "/home/lists/recent",
     },
     {
       name: "recent notes",
       href: "/home/notes/recent",
-    },
-    {
-      name: "recent links",
-      href: "/home/links/recent",
     },
   ]
 

--- a/src/enums/NotificationAgentType.ts
+++ b/src/enums/NotificationAgentType.ts
@@ -1,0 +1,5 @@
+enum NotificationAgentType {
+  User = "user_profile",
+}
+
+export default NotificationAgentType

--- a/src/enums/NotificationObjectType.ts
+++ b/src/enums/NotificationObjectType.ts
@@ -1,0 +1,9 @@
+enum NotificationObjectType {
+  BookNote = "book_note",
+  Comment = "comment",
+  List = "list",
+  User = "user_profile",
+  UserCurrentStatus = "user_current_status",
+}
+
+export default NotificationObjectType

--- a/src/enums/NotificationSourceType.ts
+++ b/src/enums/NotificationSourceType.ts
@@ -1,0 +1,6 @@
+enum NotificationSourceType {
+  Interaction = "interaction",
+  Comment = "comment",
+}
+
+export default NotificationSourceType

--- a/src/enums/NotificationType.ts
+++ b/src/enums/NotificationType.ts
@@ -1,0 +1,8 @@
+enum NotificationType {
+  Comment = "comment",
+  Follow = "follow",
+  Like = "like",
+  Mention = "mention",
+}
+
+export default NotificationType

--- a/src/lib/api/likes.ts
+++ b/src/lib/api/likes.ts
@@ -1,7 +1,9 @@
 import prisma from "lib/prisma"
+import { createNotifFromLike } from "lib/server/notifs"
 import InteractionType from "enums/InteractionType"
 import InteractionAgentType from "enums/InteractionAgentType"
 import InteractionObjectType from "enums/InteractionObjectType"
+import NotificationObjectType from "enums/NotificationObjectType"
 
 enum UpdateLikeCountMode {
   Increment,
@@ -83,6 +85,10 @@ export async function findOrCreateLike({ likedObjectType, likedObjectId, userPro
     ;[createdLike] = await prisma.$transaction([createLikePromise, updateLikeCountPromise])
   } else {
     createdLike = await createLikePromise
+  }
+
+  if (Object.values(NotificationObjectType).includes(likedObjectType)) {
+    await createNotifFromLike(createdLike)
   }
 
   return createdLike

--- a/src/lib/helpers/general.ts
+++ b/src/lib/helpers/general.ts
@@ -176,3 +176,8 @@ export async function fetchImageAsBlob(url) {
     mimeType,
   }
 }
+
+export function idsToObjects(objects) {
+  // assumes object has an id field
+  return objects.reduce((result, object) => ({ ...result, [object.id]: object }), {})
+}

--- a/src/lib/server/notifs.ts
+++ b/src/lib/server/notifs.ts
@@ -1,0 +1,85 @@
+import humps from "humps"
+import prisma from "lib/prisma"
+import { reportToSentry } from "lib/sentry"
+import InteractionObjectType from "enums/InteractionObjectType"
+import NotificationType from "enums/NotificationType"
+import NotificationAgentType from "enums/NotificationAgentType"
+import NotificationObjectType from "enums/NotificationObjectType"
+import NotificationSourceType from "enums/NotificationSourceType"
+
+async function createNotifFromLike(likeInteraction) {
+  const {
+    id: likeId,
+    agentId,
+    objectId: likedObjectId,
+    objectType: likedObjectType,
+  } = likeInteraction
+
+  if (!Object.values(NotificationObjectType).includes(likedObjectType)) {
+    reportToSentry(new Error("Invalid liked object type"), {
+      likeInteraction,
+    })
+    return
+  }
+
+  let notifiedUserProfileId
+
+  if (
+    likedObjectType === InteractionObjectType.BookNote ||
+    likedObjectType === InteractionObjectType.List
+  ) {
+    const modelName = humps.camelize(likedObjectType)
+
+    // @ts-ignore dynamic model name
+    const likedObject = await prisma[modelName].findFirst({
+      where: {
+        id: likedObjectId,
+      },
+    })
+
+    if (likedObject) {
+      notifiedUserProfileId = likedObject.creatorId
+    } else {
+      reportToSentry(new Error("Liked object not found, can't create notif"), {
+        likeInteraction,
+      })
+    }
+  } else if (likedObjectType === InteractionObjectType.Comment) {
+    const comment = await prisma.comment.findFirst({
+      where: {
+        id: likedObjectId,
+      },
+    })
+
+    if (comment) {
+      notifiedUserProfileId = comment.commenterId
+    } else {
+      reportToSentry(new Error("Comment not found, can't create notif"), {
+        likeInteraction,
+      })
+    }
+  }
+
+  if (notifiedUserProfileId) {
+    const notifData = {
+      agentId,
+      agentType: NotificationAgentType.User,
+      type: NotificationType.Like,
+      objectId: likedObjectId,
+      objectType: likedObjectType, // assuming this has been confirmed a valid NotificationObjectType
+      sourceId: likeId,
+      sourceType: NotificationSourceType.Interaction,
+      notifiedUserProfileId,
+    }
+
+    try {
+      await prisma.notification.create({
+        data: notifData,
+      })
+    } catch (error: any) {
+      reportToSentry(error, notifData)
+    }
+  }
+}
+
+export { createNotifFromLike }

--- a/src/types/Notification.ts
+++ b/src/types/Notification.ts
@@ -1,0 +1,24 @@
+import { UserProfileProps as UserProfile } from "lib/models/UserProfile"
+import NotificationAgentType from "enums/NotificationAgentType"
+import NotificationType from "enums/NotificationType"
+import NotificationObjectType from "enums/NotificationObjectType"
+import NotificationSourceType from "enums/NotificationSourceType"
+
+export default interface Notification {
+  id: string
+  agentId: string
+  agentType: NotificationAgentType
+  type: NotificationType
+  objectId: string
+  objectType: NotificationObjectType
+  sourceId: string
+  sourceType: NotificationSourceType
+  notifiedUserProfileId: string
+  read: boolean
+  createdAt: Date | string
+  updatedAt: Date | string
+  agent: UserProfile
+  object: any
+  source: any
+  notifiedUser: UserProfile
+}


### PR DESCRIPTION
conceptually, a notification has:
+ agent: the person who did the thing
+ type: the "verb" of the thing done (liked something, followed something)
+ object: the thing that was verbed
+ notified user: the followed person or the creator of the object
+ source: the object already associated with the thing (if applicable): for example the interaction object (for likes and follows), the comment. some notifications may not have a source.

for comments, note that the object is the thing of yours that was commented on, while the source is the comment itself. that way we can keep it consistent that the notified user is the notification object's creator, that's why they are being notified.

note also: for now, `read` doesn't do anything, as we are just gonna show all the most recent notifs and not distinguish between read/unread. so everything will default to "unread" and just stay that way.

in this PR:
+ adds notifs page under `/home/`
+ create a notif on follow
+ create a notif on like: for notes, posts, comments, lists
+ the above will be backfilled on staging and prod.
+ also booted "recent links" off the homepage.. as we add more relevant stuff to the homepage, we'll boot most of these feeds off and eventually put them in admin and/or under a different page for discovery.

not in this PR:
+ notifs for when someone commented on something, as this PR was already getting big and comments are not really being used on prod yet.


https://app.asana.com/0/1205114589319956/1206303074621071