### PR TITLE
at-mentions ui fixes

### DIFF
--- a/src/app/components/AtMentions.tsx
+++ b/src/app/components/AtMentions.tsx
@@ -6,7 +6,7 @@ import { idsToObjects } from "lib/helpers/general"
 import UserProfile from "lib/models/UserProfile"
 import NameWithAvatar from "app/components/userProfiles/NameWithAvatar"
 
-const LIMIT = 5
+const LIMIT = 4
 
 const bgColorToValue = {
   "bg-gray-700": "hsl(45, 8%, 37%)",
@@ -22,20 +22,27 @@ export default function AtMentions({ bgColor, formProps, moreProps, name, rows }
   const mentionsInputStyles = {
     control: {
       boxSizing: "border-box",
+      width: "100%",
       maxWidth: "100%",
       backgroundColor: bgColorToValue[bgColor],
       height,
+      overflowY: "auto",
       paddingLeft: "0.75rem",
       paddingRight: "0.75rem",
       paddingTop: "0.75rem",
       paddingBottom: "0.5rem",
+      marginBottom: "0.25rem",
     },
     input: {
       boxSizing: "border-box",
+      backgroundColor: bgColorToValue[bgColor],
+      width: "100%",
       maxWidth: "100%",
+      overflowY: "auto",
+      height,
       borderRadius: "0.25rem",
       border: "none",
-      // TODO: focus outline
+      marginBottom: "0.25rem",
     },
     suggestions: {
       list: {

--- a/src/app/components/BookNoteModal.tsx
+++ b/src/app/components/BookNoteModal.tsx
@@ -284,7 +284,7 @@ export default function BookNoteModal({
               {readingStatus && (
                 <div className="">
                   <form onSubmit={handleSubmit(submit)}>
-                    <div className="my-4">
+                    <div className="my-4 max-w-[384px]">
                       <FormTextarea
                         labelText={readingStatusToCopy[readingStatus].textPrompt}
                         name="text"
@@ -375,7 +375,9 @@ export default function BookNoteModal({
                         <button
                           type="submit"
                           className="mt-4 cat-btn cat-btn-sm cat-btn-gold"
-                          disabled={isBusy}
+                          disabled={
+                            isBusy || (!!text && text.length > bookNoteValidations.text.maxLength)
+                          }
                         >
                           save
                         </button>

--- a/src/app/components/CustomMarkdown.tsx
+++ b/src/app/components/CustomMarkdown.tsx
@@ -17,7 +17,7 @@ const components: Components = {
   a: ({ node, href, children, ...props }) => {
     if (isValidUuid(href)) {
       return (
-        <a {...props} href={getUserProfileLink(href!)} className="cat-link">
+        <a {...props} href={getUserProfileLink(href!)} className="text-gold-500">
           {children}
         </a>
       )

--- a/src/app/components/bookNotes/EditBookNote.tsx
+++ b/src/app/components/bookNotes/EditBookNote.tsx
@@ -70,7 +70,7 @@ export default function EditBookNote({ bookNote, onEditSuccess, onDeleteSuccess,
       <FormTextarea
         name="text"
         type="text"
-        rows={3}
+        rows={5}
         remainingChars={bookNoteValidations.text.maxLength - (text?.length || 0)}
         errorMessage={textErrorMsg}
         fullWidth
@@ -93,7 +93,11 @@ export default function EditBookNote({ bookNote, onEditSuccess, onDeleteSuccess,
         >
           Cancel
         </button>
-        <button disabled={isBusy} className="cat-btn cat-btn-sm cat-btn-gold" onClick={submit}>
+        <button
+          disabled={isBusy || (!!text && text.length > bookNoteValidations.text.maxLength)}
+          className="cat-btn cat-btn-sm cat-btn-gold"
+          onClick={submit}
+        >
           Save
         </button>
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+textarea:focus {
+  @apply outline-gold-500;
+}
+
 .cat-page-title {
   @apply text-2xl font-mulish lowercase;
 }

--- a/src/app/users/[username]/components/EditProfileCurrentStatus.tsx
+++ b/src/app/users/[username]/components/EditProfileCurrentStatus.tsx
@@ -132,7 +132,7 @@ export default function EditProfileCurrentStatus({
         <FormTextarea
           name="text"
           type="text"
-          rows={3}
+          rows={5}
           remainingChars={textMaxLength - (text?.length || 0)}
           errorMessage={textErrorMsg}
           fullWidth
@@ -148,7 +148,11 @@ export default function EditProfileCurrentStatus({
           >
             cancel
           </button>
-          <button disabled={isBusy} className="cat-btn cat-btn-sm cat-btn-gold" onClick={submit}>
+          <button
+            disabled={isBusy || (!!text && text.length > textMaxLength)}
+            className="cat-btn cat-btn-sm cat-btn-gold"
+            onClick={submit}
+          >
             save
           </button>
         </div>

--- a/src/app/users/[username]/lists/new/components/EditList.tsx
+++ b/src/app/users/[username]/lists/new/components/EditList.tsx
@@ -185,7 +185,6 @@ export default function EditList({ list, firstBook, currentUserProfile, isEdit =
   }
 
   const titleValue = watch("title")
-  const descriptionValue = watch("description")
   const isRanked = watch("ranked")
   const readyToSubmit = titleValue?.length > 0 && books.length > 0
 
@@ -209,7 +208,8 @@ export default function EditList({ list, firstBook, currentUserProfile, isEdit =
               labelText="description"
               name="description"
               type="text"
-              remainingChars={MAX_LENGTHS.description - (descriptionValue?.length || 0)}
+              rows={5}
+              remainingChars={MAX_LENGTHS.description - (description?.length || 0)}
               errorMessage={descriptionErrorMessage}
               fullWidth={false}
               value={description}

--- a/src/app/users/[username]/lists/new/components/SortableBook.tsx
+++ b/src/app/users/[username]/lists/new/components/SortableBook.tsx
@@ -139,7 +139,7 @@ function EditNote({ note, onCancel, onDone }) {
       <FormTextarea
         name="text"
         type="text"
-        rows={2}
+        rows={3}
         remainingChars={maxLength - (text?.length || 0)}
         errorMessage={textErrorMsg}
         fullWidth
@@ -151,7 +151,12 @@ function EditNote({ note, onCancel, onDone }) {
         <button className="mr-2 cat-btn cat-btn-sm cat-btn-white-outline" onClick={onCancel}>
           cancel
         </button>
-        <button className="cat-btn cat-btn-sm cat-btn-teal" onClick={handleDone}>
+        <button
+          type="button"
+          className="cat-btn cat-btn-sm cat-btn-teal"
+          onClick={handleDone}
+          disabled={!text || text?.length > maxLength}
+        >
           done
         </button>
       </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -72,8 +72,20 @@ module.exports = {
       },
       fontFamily: {
         "chivo-mono": ["var(--font-chivo-mono)"],
-        newsreader: ["var(--font-newsreader)"],
-        mulish: ["var(--font-mulish)"],
+        newsreader: [
+          "var(--font-newsreader)",
+          "Apple Color Emoji",
+          "Segoe UI Emoji",
+          "Noto Color Emoji",
+          "Segoe UI Symbol",
+        ],
+        mulish: [
+          "var(--font-mulish)",
+          "Apple Color Emoji",
+          "Segoe UI Emoji",
+          "Noto Color Emoji",
+          "Segoe UI Symbol",
+        ],
       },
       boxShadow: {
         black: `2px 2px 0px 0px hsl(0, 0, 0)`,


### PR DESCRIPTION
checked every @-mention-enabled textarea for:
+ appropriate size (because react-mentions makes it so you can no longer resize, ugh)
+ scrollable when text is long
+ doesn't break elements below the box when text is long
+ disable done/save button when text is too long (where applicable)
+ remaining char count works properly

also extra emoji support, just in case.
and a few minor styling tweaks.

https://app.asana.com/0/1205114589319956/1206345784307287