### PR TITLE
reduce sentry tracesSampleRate

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -21,7 +21,7 @@ if (env !== "development") {
     ],
 
     // Adjust this value in production, or use tracesSampler for greater control
-    tracesSampleRate: 1,
+    tracesSampleRate: 0.2,
 
     // Setting this option to true will print useful information to the console while you're setting up Sentry.
     debug: false,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -10,7 +10,7 @@ if (env !== "development") {
     normalizeDepth: 5,
 
     // Adjust this value in production, or use tracesSampler for greater control
-    tracesSampleRate: 1,
+    tracesSampleRate: 0.2,
 
     // Setting this option to true will print useful information to the console while you're setting up Sentry.
     debug: false,


### PR DESCRIPTION
...to keep our usage/billing down. these are just for performance metrics and there is no need to capture every event