### PR TITLE
increase timeout for non-api routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,9 @@
   "functions": {
     "src/app/api/**": {
       "maxDuration": 300
+    },
+    "src/app/**": {
+      "maxDuration": 30
     }
   }
 }


### PR DESCRIPTION
trying to see if it minimizes the 504's we've been seeing (although there is still the question of why a page should take > 15s to respond)