### PR TITLE
fix: user search not triggering

### DIFF
--- a/src/app/components/nav/Search.tsx
+++ b/src/app/components/nav/Search.tsx
@@ -82,7 +82,7 @@ export default function Search({
     }
 
     return debounce(onSearchChange, DEBOUNCE_THRESHOLD_MS)
-  }, [])
+  }, [isNav, isSignedIn])
 
   const searchUsers = async (searchString: string) => {
     setIsSearching(true)


### PR DESCRIPTION
because in PR #135 I moved the `currentUserProfile` fetch to the frontend, the `useMemo` now needs to change when that value changes.