### PR TITLE
fix: add external book to list

### DIFF
--- a/src/app/books/[bookSlug]/page.tsx
+++ b/src/app/books/[bookSlug]/page.tsx
@@ -9,6 +9,7 @@ import BookPage from "app/books/components/BookPage"
 import RemountOnPathChange from "app/components/RemountOnPathChange"
 import InteractionObjectType from "enums/InteractionObjectType"
 import type { Metadata } from "next"
+import type Book from "types/Book"
 
 export const dynamic = "force-dynamic"
 
@@ -126,8 +127,7 @@ export default async function BookPageBySlug({ params }: any) {
   return (
     <RemountOnPathChange
       ComponentToRemount={BookPage}
-      book={book}
-      isSignedIn={!!userProfile}
+      book={book as Book}
       currentUserProfile={userProfile}
     />
   )

--- a/src/app/books/components/BookPage.tsx
+++ b/src/app/books/components/BookPage.tsx
@@ -61,11 +61,9 @@ enum ConversationsTab {
 
 export default function BookPage({
   book,
-  isSignedIn,
   currentUserProfile,
 }: {
   book: Book
-  isSignedIn: boolean
   currentUserProfile: UserProfileProps
 }) {
   const searchParams = useSearchParams()
@@ -360,6 +358,8 @@ export default function BookPage({
       getCurrentUserShelf(dbBook),
     ])
   }
+
+  const isSignedIn = !!currentUserProfile
 
   const totalShelfCounts = humps.decamelizeKeys(bookActivity.totalShelfCounts) || {}
   const totalFavoritedCount = bookActivity.totalFavoritedCount || 0

--- a/src/app/books/edit/page.tsx
+++ b/src/app/books/edit/page.tsx
@@ -8,7 +8,7 @@ import { getBookEditLink } from "lib/helpers/general"
 
 export const dynamic = "force-dynamic"
 
-export default async function BookPageByQuery({ searchParams }) {
+export default async function EditBookPage({ searchParams }) {
   const { openLibraryWorkId, openLibraryEditionId: openLibraryBestEditionId } =
     humps.camelizeKeys(searchParams)
 

--- a/src/app/books/page.tsx
+++ b/src/app/books/page.tsx
@@ -5,7 +5,6 @@ import OpenLibrary from "lib/openLibrary"
 import { getCurrentUserProfile } from "lib/server/auth"
 import { reportToSentry } from "lib/sentry"
 import { getBookLink } from "lib/helpers/general"
-import { decorateLists } from "lib/server/decorators"
 import BookPage from "app/books/components/BookPage"
 import RemountOnPathChange from "app/components/RemountOnPathChange"
 import type { Metadata } from "next"
@@ -71,29 +70,6 @@ export default async function BookPageByQuery({ searchParams }) {
 
   const userProfile = await getCurrentUserProfile()
 
-  let userLists: any[] = []
-
-  if (userProfile) {
-    const _userLists = await prisma.list.findMany({
-      where: {
-        ownerId: userProfile.id,
-        designation: null,
-      },
-      orderBy: {
-        createdAt: "desc",
-      },
-      include: {
-        listItemAssignments: {
-          orderBy: {
-            sortOrder: "asc",
-          },
-        },
-      },
-    })
-
-    userLists = await decorateLists(_userLists, userProfile)
-  }
-
   const book = {
     ...openLibraryBook,
     likeCount: 0,
@@ -103,8 +79,7 @@ export default async function BookPageByQuery({ searchParams }) {
     <RemountOnPathChange
       ComponentToRemount={BookPage}
       book={book}
-      isSignedIn={!!userProfile}
-      userLists={userLists}
+      currentUserProfile={userProfile}
     />
   )
 }

--- a/src/app/components/RemountOnPathChange.tsx
+++ b/src/app/components/RemountOnPathChange.tsx
@@ -1,8 +1,17 @@
 "use client"
 
 import { usePathname, useSearchParams } from "next/navigation"
+import type Book from "types/Book"
+import type { UserProfileProps } from "lib/models/UserProfile"
 
-export default function RemountOnPathChange({ ComponentToRemount, ...props }) {
+type BookPageProps = {
+  book: Book
+  currentUserProfile: UserProfileProps
+}
+
+type Props = BookPageProps & { ComponentToRemount: React.ComponentType<BookPageProps> }
+
+export default function RemountOnPathChange({ ComponentToRemount, ...props }: Props) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
 

--- a/src/types/UserBookShelfAssignment.ts
+++ b/src/types/UserBookShelfAssignment.ts
@@ -5,6 +5,6 @@ export default interface UserBookShelfAssignment {
   shelf: UserBookShelf
   bookId: string
   userProfileId: string
-  createdAt?: string
-  updatedAt?: string
+  createdAt?: Date | string
+  updatedAt?: Date | string
 }


### PR DESCRIPTION
fixes reported bug where you can't add an external book to an existing list via "add to lists" modal. most likely introduced in #138. it was also obscured by the fact that the book page uses `RemountOnPathChange` which makes it non-obvious when the props have drifted out of sync, so that is also addressed here by explicitly specifying the expected props.