### PR TITLE
fix: error on edit blank status

### DIFF
--- a/src/app/users/[username]/components/EditProfileCurrentStatus.tsx
+++ b/src/app/users/[username]/components/EditProfileCurrentStatus.tsx
@@ -15,7 +15,7 @@ export default function EditProfileCurrentStatus({
   onCancel,
 }) {
   const [selectedBook, setSelectedBook] = useState<Book | null | undefined>(userCurrentStatus?.book)
-  const [text, setText] = useState<string>(userCurrentStatus?.text)
+  const [text, setText] = useState<string>(userCurrentStatus?.text || "")
   const [textErrorMsg, setTextErrorMsg] = useState<string>()
   const [isBusy, setIsBusy] = useState<boolean>(false)
   const [showBookSearch, setShowBookSearch] = useState<boolean>(false)


### PR DESCRIPTION
I'm actually not sure how new users were NOT hitting this error when putting in a status for the first time, but.. current status text must be a string (for react-mentions code, mostly)

[sentry](https://catalog-fm.sentry.io/issues/5029367785/?project=4506421171650560&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=90d&stream_index=6)

https://app.asana.com/0/1205114589319956/1206732270617062