### PR TITLE
profile page: reduce db calls

### DIFF
--- a/src/app/users/[username]/bookNotes/components/ProfileBookNotes.tsx
+++ b/src/app/users/[username]/bookNotes/components/ProfileBookNotes.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import Link from "next/link"
 import api from "lib/api"
 import { reportToSentry } from "lib/sentry"
@@ -13,16 +13,7 @@ const BOOK_NOTES_LIMIT = 3
 export default function BookNotes({ userProfile, currentUserProfile }: any) {
   const [notes, setNotes] = useState<any[]>([])
 
-  useEffect(() => {
-    const _notes =
-      (userProfile.bookNotes || [])
-        .filter((note) => note.noteType === BookNoteType.JournalEntry && !!note.text)
-        .slice(0, BOOK_NOTES_LIMIT) || []
-
-    setNotes(_notes)
-  }, [userProfile.bookNotes])
-
-  async function getBookNotes() {
+  const getBookNotes = useCallback(async () => {
     const requestData = {
       userProfileId: userProfile.id,
       limit: BOOK_NOTES_LIMIT,
@@ -40,7 +31,11 @@ export default function BookNotes({ userProfile, currentUserProfile }: any) {
         currentUserProfile,
       })
     }
-  }
+  }, [currentUserProfile, userProfile.id])
+
+  useEffect(() => {
+    getBookNotes()
+  }, [getBookNotes, userProfile.id])
 
   return (
     notes.length > 0 && (

--- a/src/app/users/[username]/components/UserProfilePageComponent.tsx
+++ b/src/app/users/[username]/components/UserProfilePageComponent.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import Link from "next/link"
+import UserProfile from "lib/models/UserProfile"
+import { getUserListsLink, getNewListLink } from "lib/helpers/general"
+import ProfileCurrentStatus from "app/users/[username]/components/ProfileCurrentStatus"
+import ProfileBookNotes from "app/users/[username]/bookNotes/components/ProfileBookNotes"
+import ListBook from "app/lists/components/ListBook"
+import ListCard from "app/components/lists/ListCard"
+import EmptyState from "app/components/EmptyState"
+
+export default function UserProfilePageComponent({
+  userProfile,
+  currentUserProfile,
+  lists,
+  favoriteBooksList,
+  hasPinnedLists,
+}) {
+  const isUsersProfile = currentUserProfile?.id === userProfile.id
+
+  const { name } = UserProfile.build(userProfile)
+
+  return (
+    <div className="mt-4 flex flex-col lg:flex-row">
+      <div className="lg:w-64 mt-4 lg:mr-16 font-mulish">
+        <ProfileCurrentStatus
+          userProfile={userProfile}
+          // @ts-ignore
+          userCurrentStatus={userProfile.currentStatuses[0]}
+          isUsersProfile={isUsersProfile}
+        />
+      </div>
+      <div className="xs:w-[400px] sm:w-[600px] lg:w-[640px] mt-8 lg:mt-4">
+        <div className="font-mulish">
+          <div className="cat-eyebrow">favorite books</div>
+          <hr className="my-1 h-[1px] border-none bg-gray-300" />
+          {favoriteBooksList?.books && favoriteBooksList.books.length > 0 ? (
+            <div className="p-0 grid grid-cols-4 sm:gap-[28px]">
+              {favoriteBooksList.books.map((book) => (
+                <ListBook key={book!.id} book={book} isFavorite />
+              ))}
+            </div>
+          ) : (
+            <div className="h-48 flex items-center justify-center text-center font-newsreader italic text-lg text-gray-300">
+              {isUsersProfile ? "You haven't" : `${name} hasn't`} added any favorite books yet.
+              {isUsersProfile && (
+                <>
+                  <br />
+                  Edit your profile to add some.
+                </>
+              )}
+            </div>
+          )}
+        </div>
+
+        <ProfileBookNotes userProfile={userProfile} currentUserProfile={currentUserProfile} />
+
+        <div className="mt-16 font-mulish">
+          <div className="flex justify-between text-gray-300 text-sm">
+            <div className="cat-eyebrow">{hasPinnedLists ? "pinned lists" : "recent lists"}</div>
+            <div
+              className={`flex flex-col xs:flex-row items-end xs:items-stretch ${
+                isUsersProfile ? "-mt-10 xs:-mt-3" : ""
+              }`}
+            >
+              {isUsersProfile && (
+                <Link href={getNewListLink(currentUserProfile)}>
+                  <button className="cat-btn cat-btn-sm cat-btn-gray mx-2 mb-1 xs:mb-0">
+                    + create a list
+                  </button>
+                </Link>
+              )}
+              <Link
+                className={`inline-block ${isUsersProfile ? "my-1 xs:mb-0" : ""} mx-2`}
+                href={getUserListsLink(userProfile.username)}
+              >
+                {isUsersProfile ? "manage / more" : "more"}
+              </Link>
+            </div>
+          </div>
+          <hr className="my-1 h-[1px] border-none bg-gray-300" />
+          {lists.length > 0 ? (
+            <div className="">
+              {lists.map((list) => (
+                <ListCard key={list.id} list={list} />
+              ))}
+            </div>
+          ) : (
+            <EmptyState
+              text={`${isUsersProfile ? "You haven't" : `${name} hasn't`} created any lists yet.`}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/models/UserProfile.ts
+++ b/src/lib/models/UserProfile.ts
@@ -20,6 +20,7 @@ export interface UserProfileProps {
   followers?: UserProfileProps[]
   following?: UserProfileProps[]
   editLogs?: EditLog[]
+  pins?: any[]
 }
 
 export default class UserProfile {
@@ -55,6 +56,8 @@ export default class UserProfile {
 
   public editLogs: EditLog[] | undefined
 
+  public pins: any[] | undefined
+
   constructor(userProfileProps: UserProfileProps) {
     this.id = userProfileProps.id
     this.userId = userProfileProps.userId
@@ -70,6 +73,7 @@ export default class UserProfile {
     this.bookReads = userProfileProps.bookReads
     this.currentStatuses = userProfileProps.currentStatuses
     this.editLogs = userProfileProps.editLogs
+    this.pins = userProfileProps.pins
 
     if (userProfileProps.followers) {
       this.followers = UserProfile.buildMany(userProfileProps.followers)


### PR DESCRIPTION
starting with these for now, and will see whether we get fewer timeouts.

+ extract UserProfilePageComponent into client-side component
  + not strictly necessary but just for code cleanliness
+ remove bookNotes call, fetch from frontend
+ remove `decorateWithFollowers` call-- it seems unused on this page
+ remove extra query for `pins`; include them in initial `userProfile` query instead

https://app.asana.com/0/1205114589319956/1206675161148859