### PR TITLE
global create

### DIFF
--- a/src/app/books/[bookSlug]/edit/components/EditBookCovers.tsx
+++ b/src/app/books/[bookSlug]/edit/components/EditBookCovers.tsx
@@ -304,7 +304,7 @@ export default function EditBookCovers({ book }) {
         type="button"
         onClick={submit}
         disabled={(!selectedCoverUrl && !urlInput) || isSubmitting}
-        className="my-8 cat-btn cat-btn-gold"
+        className="my-8 cat-btn cat-btn-sm cat-btn-gold"
       >
         save
       </button>

--- a/src/app/books/[bookSlug]/lists/page.tsx
+++ b/src/app/books/[bookSlug]/lists/page.tsx
@@ -49,7 +49,6 @@ export default async function BookListsIndexPage({ params }) {
     orderBy: {
       createdAt: "desc",
     },
-    take: 3,
   })
 
   const lists = await decorateLists(_lists, currentUserProfile)

--- a/src/app/books/components/BookPage.tsx
+++ b/src/app/books/components/BookPage.tsx
@@ -58,7 +58,13 @@ export default function BookPage({
 }) {
   const searchParams = useSearchParams()
   const { fetchShelfAssignments } = useUserBooks()
-  const { setCurrentBook, setCurrentModal, setExistingBookRead, setOnNewNoteSuccess } = useModals()
+  const {
+    setPotentialCurrentBook,
+    setCurrentBook,
+    setCurrentModal,
+    setExistingBookRead,
+    setOnNewNoteSuccess,
+  } = useModals()
 
   const [bookLists, setBookLists] = useState<List[]>()
   const [bookActivity, setBookActivity] = useState<BookActivity>({} as any)
@@ -70,8 +76,8 @@ export default function BookPage({
   const [showShelvesAddNoteTooltip, setShowShelvesAddNoteTooltip] = useState<boolean>(false)
 
   useEffect(() => {
-    setCurrentBook(book)
-  }, [book, setCurrentBook])
+    setPotentialCurrentBook(book)
+  }, [book, setPotentialCurrentBook])
 
   const imgRef = useRef(null)
 
@@ -269,6 +275,11 @@ export default function BookPage({
     setOnNewNoteSuccess(() => refetchBookData)
   }, [setOnNewNoteSuccess, refetchBookData])
 
+  function showModal(modalType: CurrentModal) {
+    setCurrentBook(book)
+    setCurrentModal(modalType)
+  }
+
   const isSignedIn = !!currentUserProfile
 
   const totalShelfCounts = humps.decamelizeKeys(bookActivity.totalShelfCounts) || {}
@@ -327,7 +338,7 @@ export default function BookPage({
                 >
                   <button
                     onClick={() => {
-                      setCurrentModal(CurrentModal.NewNote)
+                      showModal(CurrentModal.NewNote)
                       setShowLikeAddNoteTooltip(false)
                     }}
                   >
@@ -350,7 +361,7 @@ export default function BookPage({
                 >
                   <button
                     onClick={() => {
-                      setCurrentModal(CurrentModal.NewNote)
+                      showModal(CurrentModal.NewNote)
                       setShowShelvesAddNoteTooltip(false)
                     }}
                   >
@@ -405,7 +416,7 @@ export default function BookPage({
               <div className="mt-4 mb-8 font-mulish">
                 <button
                   type="button"
-                  onClick={() => setCurrentModal(CurrentModal.AddBookToLists)}
+                  onClick={() => showModal(CurrentModal.AddBookToLists)}
                   className="my-1 w-full cat-btn cat-btn-sm bg-gray-800 text-gray-200 hover:text-white"
                 >
                   <FaPlus className="inline-block -mt-[5px] mr-1 text-[14px]" /> add to list
@@ -413,7 +424,7 @@ export default function BookPage({
 
                 <button
                   type="button"
-                  onClick={() => setCurrentModal(CurrentModal.NewNote)}
+                  onClick={() => showModal(CurrentModal.NewNote)}
                   className="my-1 w-full cat-btn cat-btn-sm bg-gray-800 text-gray-200 hover:text-white"
                 >
                   <BsJournalText className="inline-block -mt-[4px] mr-1 text-[16px]" /> add note or

--- a/src/app/components/GlobalCreateModal.tsx
+++ b/src/app/components/GlobalCreateModal.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import Link from "next/link"
+import { Dialog } from "@headlessui/react"
+import { BsXLg, BsJournalText } from "react-icons/bs"
+import { FaPlus, FaRegComment } from "react-icons/fa"
+import { useModals } from "lib/contexts/ModalsContext"
+import { getBookLinkAgnostic } from "lib/helpers/general"
+import Search from "app/components/nav/Search"
+import CoverPlaceholder from "app/components/books/CoverPlaceholder"
+import UserBookShelfMenu, {
+  MenuButtonShape,
+} from "app/components/userBookShelves/UserBookShelfMenu"
+import CurrentModal from "enums/CurrentModal"
+
+export default function GlobalCreateModal({
+  onClose,
+  isOpen,
+}: {
+  onClose: () => void
+  isOpen: boolean
+}) {
+  const { currentBook, setCurrentBook, potentialCurrentBook, setCurrentModal } = useModals()
+
+  return (
+    <Dialog open={isOpen} onClose={onClose} className="relative z-10">
+      <div className="fixed inset-0 bg-black/80" aria-hidden="true" />
+      <div className="fixed inset-0 flex w-screen items-center justify-center font-mulish">
+        <Dialog.Panel
+          className={`relative rounded max-h-[90vh] ${
+            currentBook && "overflow-y-auto"
+          } max-w-xs xs:max-w-md sm:max-w-xl md:max-w-none bg-gray-950 border border-gray-700 px-8 sm:px-16 py-8`}
+        >
+          <button onClick={onClose} className="absolute top-[24px] right-[24px]">
+            <BsXLg className="text-xl" />
+          </button>
+
+          {currentBook ? (
+            <div className="mt-4 flex flex-col md:flex-row">
+              <div className="shrink-0 w-36">
+                {currentBook.coverImageUrl ? (
+                  <img
+                    src={currentBook.coverImageUrl}
+                    alt="cover"
+                    className="w-full mx-auto shadow-md rounded-md"
+                  />
+                ) : (
+                  <CoverPlaceholder size="md" />
+                )}
+
+                <button
+                  onClick={() => setCurrentBook(undefined)}
+                  className="cat-btn-link text-sm text-gray-300"
+                >
+                  change book
+                </button>
+              </div>
+              <div className="mt-8 md:mt-0 md:ml-8">
+                <div className="">
+                  <div className="grow text-2xl font-semibold font-newsreader">
+                    {currentBook.title}
+                  </div>
+                  <div className="text-gray-300 text-lg font-newsreader">
+                    by {currentBook.authorName}
+                  </div>
+
+                  <div className="my-4">What do you want to do?</div>
+
+                  <div className="my-4">
+                    <UserBookShelfMenu
+                      book={currentBook}
+                      menuButtonShape={MenuButtonShape.Button}
+                    />
+
+                    <button
+                      type="button"
+                      onClick={() => setCurrentModal(CurrentModal.AddBookToLists)}
+                      className="block my-4 cat-btn cat-btn-md cat-btn-light-gray text-gray-200 hover:text-white"
+                    >
+                      <FaPlus className="inline-block -mt-[5px] mr-1 text-[14px]" /> add book to
+                      list(s)
+                    </button>
+
+                    <button
+                      type="button"
+                      onClick={() => setCurrentModal(CurrentModal.NewNote)}
+                      className="block my-4 cat-btn cat-btn-md cat-btn-teal text-gray-200 hover:text-white"
+                    >
+                      <BsJournalText className="inline-block -mt-[4px] mr-1 text-[16px]" /> log this
+                      book or write a note
+                    </button>
+
+                    <button
+                      onClick={() => setCurrentModal(CurrentModal.NewPost)}
+                      className="block my-4 cat-btn cat-btn-md cat-btn-green text-gray-200 hover:text-white"
+                    >
+                      <FaRegComment className="inline-block -mt-[4px] mr-1 text-[16px]" /> create a
+                      thread
+                    </button>
+
+                    <Link
+                      href={getBookLinkAgnostic(currentBook)}
+                      className="underline text-gray-300"
+                    >
+                      go to book page
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div>
+              <div className="cat-eyebrow-uppercase">add to your books, or post about...</div>
+
+              <div className="my-4">
+                <Search
+                  isNav={false}
+                  onSelect={(book) => setCurrentBook(book)}
+                  placeholderText="search by title and author"
+                  maxHeightClass="max-h-[calc(50vh-96px)]"
+                />
+              </div>
+
+              {potentialCurrentBook && (
+                <div className="text-gray-300">
+                  or select{" "}
+                  <button
+                    onClick={() => setCurrentBook(potentialCurrentBook)}
+                    className="text-white text-left leading-normal underline"
+                  >
+                    {potentialCurrentBook.title}
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </Dialog.Panel>
+      </div>
+    </Dialog>
+  )
+}

--- a/src/app/components/Modals.tsx
+++ b/src/app/components/Modals.tsx
@@ -5,6 +5,7 @@ import { useUser } from "lib/contexts/UserContext"
 import { useUserBooks } from "lib/contexts/UserBooksContext"
 import { useModals } from "lib/contexts/ModalsContext"
 import api from "lib/api"
+import GlobalCreateModal from "app/components/GlobalCreateModal"
 import AddBookToListsModal from "app/lists/components/AddBookToListsModal"
 import BookNoteModal from "app/components/BookNoteModal"
 import NewBookPostModal from "app/components/NewBookPostModal"
@@ -45,39 +46,43 @@ export default function Modals() {
     return null
   }
 
-  if (!currentBook) {
-    return null
-  }
-
   return (
     <>
-      {currentModal === CurrentModal.AddBookToLists && (
-        <AddBookToListsModal
-          book={currentBook}
-          userLists={userLists}
-          isOpen
-          onClose={() => setCurrentModal(undefined)}
-        />
+      {currentModal === CurrentModal.GlobalCreate && (
+        <GlobalCreateModal isOpen onClose={() => setCurrentModal(undefined)} />
       )}
 
-      {currentModal === CurrentModal.NewNote && (
-        <BookNoteModal
-          book={currentBook}
-          like={isBookLiked}
-          existingBookRead={existingBookRead}
-          isOpen
-          onClose={() => setCurrentModal(undefined)}
-          onSuccess={onNewNoteSuccess}
-        />
-      )}
+      {currentBook && (
+        <>
+          {currentModal === CurrentModal.AddBookToLists && (
+            <AddBookToListsModal
+              book={currentBook}
+              userLists={userLists}
+              isOpen
+              onClose={() => setCurrentModal(undefined)}
+            />
+          )}
 
-      {currentModal === CurrentModal.NewPost && (
-        <NewBookPostModal
-          book={currentBook}
-          isOpen
-          onClose={() => setCurrentModal(undefined)}
-          onSuccess={onNewPostSuccess}
-        />
+          {currentModal === CurrentModal.NewNote && (
+            <BookNoteModal
+              book={currentBook}
+              like={isBookLiked}
+              existingBookRead={existingBookRead}
+              isOpen
+              onClose={() => setCurrentModal(undefined)}
+              onSuccess={onNewNoteSuccess}
+            />
+          )}
+
+          {currentModal === CurrentModal.NewPost && (
+            <NewBookPostModal
+              book={currentBook}
+              isOpen
+              onClose={() => setCurrentModal(undefined)}
+              onSuccess={onNewPostSuccess}
+            />
+          )}
+        </>
       )}
     </>
   )

--- a/src/app/components/bookNotes/EditBookNote.tsx
+++ b/src/app/components/bookNotes/EditBookNote.tsx
@@ -99,7 +99,7 @@ export default function EditBookNote({ bookNote, onEditSuccess, onDeleteSuccess,
       <div className="flex justify-end">
         <button
           disabled={isBusy}
-          className="mr-2 cat-btn cat-btn-red-outline text-red-500"
+          className="mr-2 cat-btn cat-btn-sm cat-btn-red-outline text-red-500"
           onClick={() => setShowDeleteConfirmation(true)}
         >
           <TbTrash className="text-xl" />

--- a/src/app/components/bookPosts/EditBookPost.tsx
+++ b/src/app/components/bookPosts/EditBookPost.tsx
@@ -128,7 +128,7 @@ export default function EditBookLinkPost({ bookPost, onEditSuccess, onDeleteSucc
       <div className="flex justify-end">
         <button
           disabled={isBusy}
-          className="mr-2 cat-btn cat-btn-red-outline text-red-500"
+          className="mr-2 cat-btn cat-btn-sm cat-btn-red-outline text-red-500"
           onClick={() => setShowDeleteConfirmation(true)}
         >
           <TbTrash className="text-xl" />

--- a/src/app/components/comments/EditComment.tsx
+++ b/src/app/components/comments/EditComment.tsx
@@ -115,7 +115,7 @@ export default function EditComment({
         {comment && (
           <button
             disabled={isBusy}
-            className="mr-2 cat-btn cat-btn-red-outline text-red-500"
+            className="mr-2 cat-btn cat-btn-sm cat-btn-red-outline text-red-500"
             onClick={() => setShowDeleteConfirmation(true)}
           >
             <TbTrash className="text-xl" />

--- a/src/app/components/nav/Announcements.tsx
+++ b/src/app/components/nav/Announcements.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link"
 import { useState } from "react"
-import { BsEnvelopeFill, BsEnvelopePaperHeartFill } from "react-icons/bs"
+import { BsEnvelopePaperHeartFill } from "react-icons/bs"
 import api from "lib/api"
 import { reportToSentry } from "lib/sentry"
 
@@ -22,7 +22,7 @@ export default function Announcements({ isMobile, currentUserProfile }) {
   }
 
   const iconOpenClasses = isMobile ? "text-[24px]" : "text-[22px]"
-  const iconClosedClasses = isMobile ? "text-[24px]" : "text-[22px]"
+  // const iconClosedClasses = isMobile ? "text-[24px]" : "text-[22px]"
 
   async function readAnnouncements() {
     if (!hasNewAnnouncements) return
@@ -40,17 +40,23 @@ export default function Announcements({ isMobile, currentUserProfile }) {
     setHasNewAnnouncements(false)
   }
 
+  if (!hasNewAnnouncements) return null
+
   return (
     <button className={`relative ${buttonClasses}`} onClick={readAnnouncements}>
       <Link href="/guide">
-        {hasNewAnnouncements ? (
-          <>
-            <BsEnvelopePaperHeartFill className={`${iconOpenClasses} text-gray-200`} />
-            <span className="w-1.5 h-1.5 absolute top-3 -right-1.5 rounded-full bg-red-300" />
-          </>
-        ) : (
-          <BsEnvelopeFill className={`${iconClosedClasses} text-gray-500`} />
-        )}
+        {/* for if we need to differentiate between read/unread icons again
+          {hasNewAnnouncements ? (
+            <>
+              <BsEnvelopePaperHeartFill className={`${iconOpenClasses} text-gray-200`} />
+              <span className="w-1.5 h-1.5 absolute top-3 -right-1.5 rounded-full bg-red-300" />
+            </>
+          ) : (
+            <BsEnvelopeFill className={`${iconClosedClasses} text-gray-500`} />
+          )}
+        */}
+        <BsEnvelopePaperHeartFill className={`${iconOpenClasses} text-gray-200`} />
+        <span className="w-1.5 h-1.5 absolute top-3 -right-1.5 rounded-full bg-red-300" />
       </Link>
     </button>
   )

--- a/src/app/components/nav/Nav.tsx
+++ b/src/app/components/nav/Nav.tsx
@@ -6,12 +6,15 @@ import { useState, useEffect } from "react"
 import humps from "humps"
 import "react-modern-drawer/dist/index.css"
 import { BsSearch, BsXLg } from "react-icons/bs"
+import { FaPlus } from "react-icons/fa"
 import { useUser } from "lib/contexts/UserContext"
+import { useModals } from "lib/contexts/ModalsContext"
 import { getUserProfileLink } from "lib/helpers/general"
 import { reportToSentry } from "lib/sentry"
 import Search from "app/components/nav/Search"
 import UserNav from "app/components/nav/UserNav"
 import Announcements from "app/components/nav/Announcements"
+import CurrentModal from "enums/CurrentModal"
 import type Book from "types/Book"
 
 const Drawer = dynamic(() => import("react-modern-drawer"), { ssr: false })
@@ -22,6 +25,7 @@ export default function Nav() {
   const searchParams = useSearchParams()
 
   const { isFetching: isLoading, currentUserProfile } = useUser()
+  const { setCurrentModal } = useModals()
 
   const navigate = (item, type) => {
     if (type === "books") return navigateToBookPage(item)
@@ -63,6 +67,7 @@ export default function Nav() {
           currentUserProfile={currentUserProfile}
           isLoading={isLoading}
           onSelectItem={navigate}
+          setCurrentModal={setCurrentModal}
         />
       </div>
       <div className="hidden lg:inline-block">
@@ -70,13 +75,14 @@ export default function Nav() {
           currentUserProfile={currentUserProfile}
           isLoading={isLoading}
           onSelectItem={navigate}
+          setCurrentModal={setCurrentModal}
         />
       </div>
     </>
   )
 }
 
-function MobileNav({ currentUserProfile, isLoading, onSelectItem }) {
+function MobileNav({ currentUserProfile, isLoading, onSelectItem, setCurrentModal }) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const [showMobileSearch, setShowMobileSearch] = useState(false)
@@ -95,15 +101,23 @@ function MobileNav({ currentUserProfile, isLoading, onSelectItem }) {
   }
 
   return (
-    <div className="flex">
-      <button className="mt-1 px-2" onClick={() => setShowMobileSearch(true)}>
+    <div className="flex items-center">
+      <button className="px-2" onClick={() => setShowMobileSearch(true)}>
         <BsSearch className="text-[24px] text-gray-200" />
       </button>
+
       {currentUserProfile && <Announcements currentUserProfile={currentUserProfile} isMobile />}
+
+      {currentUserProfile && (
+        <div className="mx-2">
+          <CreateButton setCurrentModal={setCurrentModal} />
+        </div>
+      )}
+
       {isLoading ? (
-        <div className="ml-2 mt-1 h-6 w-6 bg-gray-500 rounded-full animate-pulse" />
+        <div className="ml-2 -mt-1 h-6 w-6 bg-gray-500 rounded-full animate-pulse" />
       ) : (
-        <div className="mt-1.5">
+        <div className="-mt-0.5">
           <UserNav currentUserProfile={currentUserProfile} />
         </div>
       )}
@@ -130,17 +144,24 @@ function MobileNav({ currentUserProfile, isLoading, onSelectItem }) {
   )
 }
 
-function DesktopNav({ currentUserProfile, isLoading, onSelectItem }) {
+function DesktopNav({ currentUserProfile, isLoading, onSelectItem, setCurrentModal }) {
   return (
     <div className="flex">
-      <div className="mr-10">
+      <div className="mr-8">
         <Search onSelect={onSelectItem} isSignedIn={!!currentUserProfile} />
       </div>
 
-      <div className="flex">
+      <div className="flex items-center">
         {currentUserProfile && (
           <Announcements currentUserProfile={currentUserProfile} isMobile={false} />
         )}
+
+        {currentUserProfile && (
+          <div className="mr-2.5 my-2">
+            <CreateButton setCurrentModal={setCurrentModal} />
+          </div>
+        )}
+
         <div className="mr-4 mt-2">
           {isLoading ? (
             <div className="h-6 w-6 bg-gray-500 rounded-full animate-pulse" />
@@ -150,5 +171,16 @@ function DesktopNav({ currentUserProfile, isLoading, onSelectItem }) {
         </div>
       </div>
     </div>
+  )
+}
+
+function CreateButton({ setCurrentModal }) {
+  return (
+    <button
+      onClick={() => setCurrentModal(CurrentModal.GlobalCreate)}
+      className="cat-btn p-2 cat-btn-gold"
+    >
+      <FaPlus className="text-xs text-black" />
+    </button>
   )
 }

--- a/src/app/components/nav/Search.tsx
+++ b/src/app/components/nav/Search.tsx
@@ -26,6 +26,8 @@ type Props = {
   disabledMessage?: string
   fullWidth?: boolean
   isSignedIn?: boolean
+  placeholderText?: string
+  maxHeightClass?: string
 }
 
 const concatUniqueSearchResults = (resultsA, resultsB) => {
@@ -45,6 +47,8 @@ export default function Search({
   disabledMessage,
   fullWidth: _fullWidth,
   isSignedIn = false,
+  placeholderText,
+  maxHeightClass = "max-h-[calc(100vh-192px)]",
 }: Props) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -214,15 +218,17 @@ export default function Search({
     searchMode === "books" && ((isSearching && !searchResults) || !!selectedBook)
   const isLoadingMoreBooksResults = searchMode === "books" && isSearching && searchResults
 
-  let placeholder
-  if (isNav) {
-    if (isSignedIn) {
-      placeholder = "book title and author (or @ for user)"
+  let placeholder = placeholderText
+  if (!placeholder) {
+    if (isNav) {
+      if (isSignedIn) {
+        placeholder = "book title and author (or @ for user)"
+      } else {
+        placeholder = "search by title and author"
+      }
     } else {
-      placeholder = "search by title and author"
+      placeholder = "add by title and author"
     }
-  } else {
-    placeholder = "add by title and author"
   }
 
   return (
@@ -258,6 +264,7 @@ export default function Search({
                     <UserSearchResults
                       isLoading={isLoadingUsers}
                       searchResults={userSearchResults}
+                      maxHeightClass={maxHeightClass}
                     />
                   ) : (
                     <BookSearchResults
@@ -265,6 +272,7 @@ export default function Search({
                       searchResults={searchResults}
                       isLoadingMoreResults={isLoadingMoreBooksResults}
                       moreResultsExist={moreResultsExist}
+                      maxHeightClass={maxHeightClass}
                     />
                   )}
                 </Combobox.Options>
@@ -277,7 +285,7 @@ export default function Search({
   )
 }
 
-function UserSearchResults({ isLoading, searchResults }) {
+function UserSearchResults({ isLoading, searchResults, maxHeightClass }) {
   return (
     <>
       {isLoading && (
@@ -290,7 +298,7 @@ function UserSearchResults({ isLoading, searchResults }) {
         <div className="px-6 py-3">No users found.</div>
       )}
       {!isLoading && searchResults && searchResults.length > 0 && (
-        <div className="max-h-[calc(100vh-192px)] overflow-y-auto">
+        <div className={`${maxHeightClass} overflow-y-auto`}>
           {searchResults.map((userProfile) => (
             <Combobox.Option key={userProfile.id} value={userProfile} as={Fragment}>
               {({ active }) => (
@@ -310,7 +318,13 @@ function UserSearchResults({ isLoading, searchResults }) {
   )
 }
 
-function BookSearchResults({ isLoading, searchResults, isLoadingMoreResults, moreResultsExist }) {
+function BookSearchResults({
+  isLoading,
+  searchResults,
+  isLoadingMoreResults,
+  moreResultsExist,
+  maxHeightClass,
+}) {
   return (
     <>
       {isLoading && (
@@ -323,7 +337,7 @@ function BookSearchResults({ isLoading, searchResults, isLoadingMoreResults, mor
         <div className="px-6 py-3">No books found.</div>
       )}
       {!isLoading && searchResults && searchResults.length > 0 && (
-        <div className="max-h-[calc(100vh-192px)] overflow-y-auto">
+        <div className={`${maxHeightClass} overflow-y-auto`}>
           {searchResults.map((book) => (
             <Combobox.Option key={book.openLibraryWorkId} value={book} as={Fragment}>
               {({ active }) => (

--- a/src/app/components/nav/SignInForm.tsx
+++ b/src/app/components/nav/SignInForm.tsx
@@ -59,7 +59,7 @@ export default function SignInForm({ toggleAuth, onSuccess }) {
         value={password}
       />
       <button
-        className="cat-btn cat-btn-gold my-2"
+        className="cat-btn cat-btn-md cat-btn-gold my-2"
         onClick={handleSubmit}
         disabled={isSubmitting || !email || !password}
       >

--- a/src/app/components/nav/SignUpForm.tsx
+++ b/src/app/components/nav/SignUpForm.tsx
@@ -104,7 +104,11 @@ export default function SignUpForm({
         textColor="text-teal-500"
         focusColor="focus:ring-teal-500"
       />
-      <button className="cat-btn cat-btn-teal my-4" onClick={handleSubmit} disabled={isSubmitting}>
+      <button
+        className="cat-btn cat-btn-md cat-btn-teal my-4"
+        onClick={handleSubmit}
+        disabled={isSubmitting}
+      >
         Sign up
       </button>
       {errorMessage && <div className="my-3 text-red-500">{errorMessage}</div>}

--- a/src/app/components/userBookShelves/UserBookShelfMenu.tsx
+++ b/src/app/components/userBookShelves/UserBookShelfMenu.tsx
@@ -12,13 +12,24 @@ import type Book from "types/Book"
 
 const SHELVES = Object.values(UserBookShelf)
 
+enum MenuButtonShape {
+  Icon,
+  Button,
+}
+
 type Props = {
   book: Book
   onChange?: (shelf: UserBookShelf) => void
   compact?: boolean
+  menuButtonShape?: MenuButtonShape
 }
 
-export default function UserBookShelfMenu({ book, onChange, compact = false }: Props) {
+export default function UserBookShelfMenu({
+  book,
+  onChange,
+  compact = false,
+  menuButtonShape = MenuButtonShape.Icon,
+}: Props) {
   const { bookIdsToShelves, shelveBook, unshelveBook, isLoading } = useUserBooks()
   const currentUserShelf = book.id ? bookIdsToShelves[book.id] : undefined
 
@@ -93,24 +104,32 @@ export default function UserBookShelfMenu({ book, onChange, compact = false }: P
     }
   }
 
-  if (isLoading) return <FaBookmark className="text-gray-500 text-sm animate-pulse" />
+  if (isLoading && menuButtonShape === MenuButtonShape.Icon) {
+    return <FaBookmark className="text-gray-500 text-sm animate-pulse" />
+  }
 
   return (
     <Menu>
       <Float placement="right" offset={10} flip>
-        <Menu.Button className="flex items-center cat-btn-text text-sm">
-          {selectedShelf ? (
-            <div className="flex items-center">
-              <FaBookmark className="text-gold-500 text-sm" />
-              {!compact && <div className="ml-1.5">{shelfToCopy[selectedShelf]}</div>}
-            </div>
-          ) : (
-            <div className="flex items-center text-gray-300">
-              <FaRegBookmark className="text-gray-300 text-sm" />
-              {!compact && <div className="ml-1.5">shelves</div>}
-            </div>
-          )}
-        </Menu.Button>
+        {menuButtonShape === MenuButtonShape.Icon ? (
+          <Menu.Button className="flex items-center cat-btn-text text-sm">
+            {selectedShelf ? (
+              <div className="flex items-center">
+                <FaBookmark className="text-gold-500 text-sm" />
+                {!compact && <div className="ml-1.5">{shelfToCopy[selectedShelf]}</div>}
+              </div>
+            ) : (
+              <div className="flex items-center text-gray-300">
+                <FaRegBookmark className="text-gray-300 text-sm" />
+                {!compact && <div className="ml-1.5">shelves</div>}
+              </div>
+            )}
+          </Menu.Button>
+        ) : (
+          <Menu.Button className="block my-4 cat-btn cat-btn-md cat-btn-gold" disabled={isLoading}>
+            <FaRegBookmark className="inline-block -mt-1 mr-1 text-[16px]" /> shelve book
+          </Menu.Button>
+        )}
         <Menu.Items className="w-[144px] bg-gray-900 rounded">
           {SHELVES.map((shelf) => (
             <Menu.Item key={shelf}>
@@ -129,3 +148,5 @@ export default function UserBookShelfMenu({ book, onChange, compact = false }: P
     </Menu>
   )
 }
+
+export { MenuButtonShape }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,7 +29,6 @@ textarea:focus {
 
 .cat-btn {
   @apply font-mulish font-semibold lowercase rounded-sm disabled:opacity-50 shadow-black transition-all active:translate-x-[1px] active:translate-y-[1px] active:shadow-none;
-  @apply cat-btn-md;
 }
 
 .cat-btn-sm {

--- a/src/app/lists/components/AddBookToListsModal.tsx
+++ b/src/app/lists/components/AddBookToListsModal.tsx
@@ -6,15 +6,18 @@ import { Dialog } from "@headlessui/react"
 import { toast } from "react-hot-toast"
 import { BsXLg } from "react-icons/bs"
 import { FaCheck, FaPlus } from "react-icons/fa6"
+import { useModals } from "lib/contexts/ModalsContext"
 import api from "lib/api"
 import { reportToSentry } from "lib/sentry"
 import { useUser } from "lib/contexts/UserContext"
 import { getNewListLink } from "lib/helpers/general"
+import CurrentModal from "enums/CurrentModal"
 import type List from "types/List"
 
 export default function AddBookToListsModal({ book, userLists, onClose, isOpen }) {
   const router = useRouter()
   const { currentUser } = useUser()
+  const { setCurrentBook, setCurrentModal } = useModals()
 
   const [selectedLists, setSelectedLists] = useState<List[]>([])
   const [isBusy, setIsBusy] = useState<boolean>(false)
@@ -36,6 +39,7 @@ export default function AddBookToListsModal({ book, userLists, onClose, isOpen }
 
   const handleClose = async () => {
     await onClose()
+    setCurrentBook(undefined)
   }
 
   const handleClickNewList = () => {
@@ -108,7 +112,14 @@ export default function AddBookToListsModal({ book, userLists, onClose, isOpen }
             ))}
           </div>
 
-          <div className="flex justify-end">
+          <div className="flex justify-between items-center">
+            <button
+              onClick={() => setCurrentModal(CurrentModal.GlobalCreate)}
+              className="cat-link text-sm text-gray-300"
+            >
+              back to menu
+            </button>
+
             <button
               type="button"
               onClick={handleSubmit}

--- a/src/app/settings/password/components/ResetPassword.tsx
+++ b/src/app/settings/password/components/ResetPassword.tsx
@@ -70,7 +70,7 @@ export default function ResetPassword() {
       />
 
       <button
-        className="cat-btn cat-btn-gold my-2"
+        className="cat-btn cat-btn-md cat-btn-gold my-2"
         onClick={handleSubmit}
         disabled={isSubmitting || !password || !confirmPassword}
       >

--- a/src/enums/CurrentModal.ts
+++ b/src/enums/CurrentModal.ts
@@ -1,4 +1,5 @@
 enum CurrentModal {
+  GlobalCreate = "global_create",
   AddBookToLists = "add_book_to_lists",
   NewNote = "new_note",
   NewPost = "new_post",

--- a/src/lib/contexts/ModalsContext.tsx
+++ b/src/lib/contexts/ModalsContext.tsx
@@ -11,6 +11,8 @@ type ModalsProviderValue = {
   setCurrentModal: (modal?: CurrentModal) => void
   currentBook?: Book
   setCurrentBook: (book?: Book) => void
+  potentialCurrentBook?: Book
+  setPotentialCurrentBook: (book?: Book) => void
   existingBookRead?: BookRead
   setExistingBookRead: (bookRead?: BookRead) => void
   onNewNoteSuccess: () => void
@@ -26,15 +28,21 @@ export function ModalsProvider({ children }) {
 
   const [currentModal, setCurrentModal] = useState<CurrentModal>()
   const [currentBook, setCurrentBook] = useState<Book>()
+  const [potentialCurrentBook, setPotentialCurrentBook] = useState<Book>()
   const [existingBookRead, setExistingBookRead] = useState<BookRead>()
   const [onNewNoteSuccess, setOnNewNoteSuccess] = useState<() => void>(() => {})
   const [onNewPostSuccess, setOnNewPostSuccess] = useState<() => void>(() => {})
 
   useEffect(() => {
+    setCurrentBook(undefined)
     setCurrentModal(undefined)
     setExistingBookRead(undefined)
     setOnNewNoteSuccess(() => {})
     setOnNewPostSuccess(() => {})
+
+    if (!pathname.includes("/books")) {
+      setPotentialCurrentBook(undefined)
+    }
   }, [pathname])
 
   const providerValue = useMemo(
@@ -43,6 +51,8 @@ export function ModalsProvider({ children }) {
       setCurrentModal,
       currentBook,
       setCurrentBook,
+      potentialCurrentBook,
+      setPotentialCurrentBook,
       existingBookRead,
       setExistingBookRead,
       onNewNoteSuccess,
@@ -55,6 +65,8 @@ export function ModalsProvider({ children }) {
       setCurrentModal,
       currentBook,
       setCurrentBook,
+      potentialCurrentBook,
+      setPotentialCurrentBook,
       existingBookRead,
       setExistingBookRead,
       onNewNoteSuccess,

--- a/src/lib/helpers/general.ts
+++ b/src/lib/helpers/general.ts
@@ -46,6 +46,23 @@ export const getUserListsLink = (username: string) => `/users/${username}/lists`
 
 export const getBookLink = (slug: string) => `/books/${slug}`
 
+export const getBookLinkWithOpenLibraryIds = (book) => {
+  const queryParams = {
+    openLibraryWorkId: book.openLibraryWorkId,
+    openLibraryEditionId: book.openLibraryBestEditionId,
+  }
+
+  const queryStr = new URLSearchParams(humps.decamelizeKeys(queryParams))
+  const path = `/books?${queryStr}`
+
+  return path
+}
+
+export const getBookLinkAgnostic = (book) => {
+  if (book.slug) return getBookLink(book.slug)
+  return getBookLinkWithOpenLibraryIds(book)
+}
+
 export const getBookEditLink = (slug: string) => `/books/${slug}/edit`
 
 export const getBookEditLinkWithQueryString = (queryString: any) => `/books/edit?${queryString}`


### PR DESCRIPTION
adds `+` button to nav, where you can search a book and then shelve it, add it to a list(s), create a note, or create a thread, or go to the book's page.

+ uses existing menus/modals for the actions
+ shortcut if you're currently on a book page, to select that book
+ "back to menu" links in the existing modals brings up the options for that book (regardless of whether you came from that screen)
+ uses globally managed state to keep track of which modal is active and which book is currently selected

also:
+ standardize on `cat-btn` class NOT including `@apply cat-btn-md` so that size/padding can be totally custom while still getting the hover etc behavior
+ fixes random bug encountered: don't impose limit on book lists page

https://app.asana.com/0/1205114589319956/1206097425649156