### PR TITLE
fix: refetch notes/posts on book page

### DIFF
--- a/src/app/books/components/BookPage.tsx
+++ b/src/app/books/components/BookPage.tsx
@@ -339,6 +339,7 @@ export default function BookPage({
   }
 
   const refetchBookData = useCallback(async () => {
+    console.log("refetchBookData, running")
     const dbBook = await getBook()
     Promise.all([
       updateLikes(dbBook),
@@ -348,11 +349,9 @@ export default function BookPage({
     ])
   }, [getBook, updateLikes, getBookNotes, getBookReads, fetchShelfAssignments])
 
-  useEffect(() => {
-    setOnNewNoteSuccess(() => refetchBookData)
-  }, [setOnNewNoteSuccess, refetchBookData])
-
   function showModal(modalType: CurrentModal) {
+    console.log("setting onNewNoteSuccess")
+    setOnNewNoteSuccess(() => refetchBookData)
     setCurrentBook(book)
     setCurrentModal(modalType)
   }

--- a/src/app/books/components/BookPageConversations.tsx
+++ b/src/app/books/components/BookPageConversations.tsx
@@ -100,22 +100,17 @@ export default function BookPageConversations({
     [book.id, getBook, currentUserProfile],
   )
 
-  const handleCreatedPost = useCallback(async () => {
-    console.log("handleCreatedPost")
-    setConversationsTab(ConversationsTab.Catalog)
-    if (onChange) onChange()
-    return getBookPosts()
-  }, [getBookPosts, onChange])
-
   const handleChange = useCallback(() => {
     if (onChange) onChange()
     return getBookPosts()
   }, [getBookPosts, onChange])
 
-  useEffect(() => {
-    console.log("setting onNewPostSuccess")
-    setOnNewPostSuccess(() => handleCreatedPost)
-  }, [setOnNewPostSuccess, handleCreatedPost])
+  const handleCreatedPost = useCallback(async () => {
+    console.log("onNewPostSuccess, running")
+    setConversationsTab(ConversationsTab.Catalog)
+    if (onChange) onChange()
+    return getBookPosts()
+  }, [getBookPosts, onChange])
 
   useEffect(() => {
     if (book.id) {
@@ -139,6 +134,8 @@ export default function BookPageConversations({
   }
 
   function showModal(modalType: CurrentModal) {
+    console.log("setting onNewPostSuccess")
+    setOnNewPostSuccess(() => handleCreatedPost)
     setCurrentBook(book)
     setCurrentModal(modalType)
   }

--- a/src/app/components/BookNoteModal.tsx
+++ b/src/app/components/BookNoteModal.tsx
@@ -77,19 +77,17 @@ const readingStatusToCopy = {
 export default function BookNoteModal({
   book,
   onClose,
-  onSuccess,
   isOpen,
   like: _like,
   existingBookRead: _existingBookRead,
 }: {
   book: Book
   onClose: () => void
-  onSuccess: () => void
   isOpen: boolean
   like: boolean
   existingBookRead?: BookRead
 }) {
-  const { setCurrentBook, setCurrentModal } = useModals()
+  const { setCurrentBook, setCurrentModal, onNewNoteSuccess: onSuccess } = useModals()
 
   const [readingStatus, setReadingStatus] = useState<BookNoteReadingStatus>()
   const [text, setText] = useState<string>("")
@@ -235,6 +233,9 @@ export default function BookNoteModal({
       toast.success(successMessage, { id: toastId })
 
       await handleClose()
+
+      console.log("BookNoteModal onSuccess", onSuccess)
+
       if (onSuccess) await onSuccess()
       reset()
     } catch (error: any) {

--- a/src/app/components/Modals.tsx
+++ b/src/app/components/Modals.tsx
@@ -15,14 +15,7 @@ import type List from "types/List"
 export default function Modals() {
   const { currentUserProfile } = useUser()
   const { bookIdsToLiked } = useUserBooks()
-  const {
-    currentModal,
-    setCurrentModal,
-    currentBook,
-    existingBookRead,
-    onNewNoteSuccess,
-    onNewPostSuccess,
-  } = useModals()
+  const { currentModal, setCurrentModal, currentBook, existingBookRead } = useModals()
 
   const [userLists, setUserLists] = useState<List[]>([])
 
@@ -70,7 +63,6 @@ export default function Modals() {
               existingBookRead={existingBookRead}
               isOpen
               onClose={() => setCurrentModal(undefined)}
-              onSuccess={onNewNoteSuccess}
             />
           )}
 
@@ -79,7 +71,6 @@ export default function Modals() {
               book={currentBook}
               isOpen
               onClose={() => setCurrentModal(undefined)}
-              onSuccess={onNewPostSuccess}
             />
           )}
         </>

--- a/src/app/components/NewBookPostModal.tsx
+++ b/src/app/components/NewBookPostModal.tsx
@@ -21,8 +21,8 @@ import CurrentModal from "enums/CurrentModal"
 
 const bookPostValidations = allValidations.bookPost
 
-export default function NewBookPostModal({ book, onClose, onSuccess, isOpen }) {
-  const { setCurrentBook, setCurrentModal } = useModals()
+export default function NewBookPostModal({ book, onClose, isOpen }) {
+  const { setCurrentBook, setCurrentModal, onNewPostSuccess: onSuccess } = useModals()
 
   const [text, setText] = useState<string>("")
   const [textErrorMessage, setTextErrorMessage] = useState<string>()


### PR DESCRIPTION
upon creating a note or post on the book page (via the book page's buttons), the notes/posts were failing to refetch.

in this PR:
+ each modal gets its success callback directly from the context rather than the more indirect way of going through the Modals component (this wasn't confirmed to be part of the problem, but it added unnecessary complexity)
+ set the success callbacks immediately before setting the current modal: this is the change that fixes the bug. previous the callbacks were set in a separate useEffect and something about the timing was off (too early? too late?), so that they were not registering in the target modal.

still need to test in prod, because in a previous iteration I saw this bug in prod only..

https://app.asana.com/0/1205114589319956/1206827149596270