### PR TITLE
handle bad (or no) response from OL

### DIFF
--- a/src/app/books/page.tsx
+++ b/src/app/books/page.tsx
@@ -7,6 +7,7 @@ import { reportToSentry } from "lib/sentry"
 import { getBookLink } from "lib/helpers/general"
 import BookPage from "app/books/components/BookPage"
 import RemountOnPathChange from "app/components/RemountOnPathChange"
+import ErrorPage from "app/error"
 import type { Metadata } from "next"
 
 export const dynamic = "force-dynamic"
@@ -65,7 +66,14 @@ export default async function BookPageByQuery({ searchParams }) {
     openLibraryBook = await OpenLibrary.getFullBook(openLibraryWorkId, openLibraryBestEditionId)
   } catch (error: any) {
     reportToSentry(error, { openLibraryWorkId, openLibraryBestEditionId })
-    notFound()
+
+    if (error.message?.match(/json/i) || error.message?.match(/timed out/i)) {
+      const errorMessage =
+        "Our book data partner OpenLibrary may be experiencing issues. Please try again later!"
+      return <ErrorPage errorMessage={errorMessage} />
+    } else {
+      notFound()
+    }
   }
 
   const userProfile = await getCurrentUserProfile()

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from "react"
 import { reportToSentry } from "lib/sentry"
 
-export default function ErrorPage({ error }) {
+export default function ErrorPage({ error, errorMessage }: { error?: any; errorMessage?: string }) {
   useEffect(() => {
     reportToSentry(error)
   }, [error])
@@ -11,6 +11,9 @@ export default function ErrorPage({ error }) {
   return (
     <div className="max-w-xl mx-auto py-32 px-8 text-center">
       <div className="text-xl">Oops! Something went wrong.</div>
+
+      {errorMessage && <div className="mt-4 text-md text-gray-300">{errorMessage}</div>}
+
       <div className="mt-4 text-md text-gray-300">
         It's likely that we got the error report and will look into it, but you can get in touch by{" "}
         <a href="mailto:staff@catalog.fyi" className="cat-link">

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/nextjs"
 
 function reportToSentry(error, data: any = {}) {
   console.error(error)
+  console.log(data)
 
   const sentryContext: any = {
     extra: data,


### PR DESCRIPTION
OL has been kinda sluggish/unresponsive a lot lately; this often manifests as requests that come back with something that's not JSON, but to date we haven't been logging it properly so that's all I know about it. or they just.. don't respond, which we are calling from server side, just causes _us_ to 504 as well (which is an ugly vercel white screen of death).

+ much more robust error handling/reporting in the `fetchJson` helper, including support for a 10-second timeout on all calls
+ when OL search fails due to timeout or JSON error, show a message in the search results
+ when OL call to populate an external book page fails due to timeout or JSON error, show our error page with a message specific to this.

https://app.asana.com/0/1205114589319956/1206802968073356