### PR TITLE
fix: notifs for likes on notes/posts

### DIFF
--- a/src/lib/api/likes.ts
+++ b/src/lib/api/likes.ts
@@ -3,7 +3,6 @@ import { createNotifFromLike } from "lib/server/notifs"
 import InteractionType from "enums/InteractionType"
 import InteractionAgentType from "enums/InteractionAgentType"
 import InteractionObjectType from "enums/InteractionObjectType"
-import NotificationObjectType from "enums/NotificationObjectType"
 
 enum UpdateLikeCountMode {
   Increment,
@@ -94,7 +93,7 @@ export async function findOrCreateLike({ likedObjectType, likedObjectId, userPro
     createdLike = await createLikePromise
   }
 
-  if (Object.values(NotificationObjectType).includes(likedObjectType)) {
+  if (likedObjectType !== InteractionObjectType.Book) {
     await createNotifFromLike(createdLike)
   }
 

--- a/src/lib/helpers/general.ts
+++ b/src/lib/helpers/general.ts
@@ -7,6 +7,7 @@ import { reportToSentry } from "lib/sentry"
 import { BASE_URLS_BY_ENV } from "lib/constants/urls"
 import CommentParentType from "enums/CommentParentType"
 import NotificationObjectType from "enums/NotificationObjectType"
+import InteractionObjectType from "enums/InteractionObjectType"
 
 export const fetchJson = async (url: string | URL, options: any = {}) => {
   const TIMEOUT = 10_000 // 10 seconds
@@ -246,4 +247,13 @@ export function commentParentTypeToNotificationObjectType(parentType: string) {
   }
 
   return specialMappings[parentType] || parentType
+}
+
+export function interactionObjectTypeToNotificationObjectType(objectType: string) {
+  const specialMappings = {
+    [InteractionObjectType.Note]: NotificationObjectType.BookNote,
+    [InteractionObjectType.Post]: NotificationObjectType.BookNote,
+  }
+
+  return specialMappings[objectType] || objectType
 }

--- a/src/lib/server/notifs.ts
+++ b/src/lib/server/notifs.ts
@@ -1,6 +1,9 @@
 import prisma from "lib/prisma"
 import { reportToSentry } from "lib/sentry"
-import { commentParentTypeToNotificationObjectType } from "lib/helpers/general"
+import {
+  commentParentTypeToNotificationObjectType,
+  interactionObjectTypeToNotificationObjectType,
+} from "lib/helpers/general"
 import NotificationType from "enums/NotificationType"
 import NotificationAgentType from "enums/NotificationAgentType"
 import NotificationObjectType from "enums/NotificationObjectType"
@@ -131,7 +134,9 @@ async function createNotifFromSource(source) {
 }
 
 async function createNotifFromLike(likeInteraction) {
-  const { id, agentId, objectId, objectType } = likeInteraction
+  const { id, agentId, objectId, objectType: interactionObjectType } = likeInteraction
+
+  const objectType = interactionObjectTypeToNotificationObjectType(interactionObjectType)
 
   return createNotifFromSource({
     id,


### PR DESCRIPTION
this is another notifs bug caused by the type mismatch introduced in #155 .

https://app.asana.com/0/1205114589319956/1206868529304061