### PR TITLE
fix: notifs for follow and current status hidden

### DIFF
--- a/src/lib/server/decorators.ts
+++ b/src/lib/server/decorators.ts
@@ -487,7 +487,12 @@ export const decorateNotifs = async (notifs) => {
         source = commentIdsToComments[notif.sourceId]
       }
 
-      if (!object) return null
+      const isValid =
+        !!object ||
+        notif.objectType === NotificationObjectType.User ||
+        notif.objectType === NotificationObjectType.UserCurrentStatus
+
+      if (!isValid) return null
 
       return {
         ...notif,


### PR DESCRIPTION
some previous PR fixed things so that a notif for a deleted object is never shown, ie, the notif requires its object to be present. however, it needed to take into account that when the object is a user (for "follow" notifs) or is a user current status (for "liked your current status" notifs) the object actually isn't needed and shouldn't be required.