### PR TITLE
private shelves

### DIFF
--- a/prisma/migrations/20240409173829_add_shelves_visibility_to_user_configs/migration.sql
+++ b/prisma/migrations/20240409173829_add_shelves_visibility_to_user_configs/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user_configs" ADD COLUMN     "shelves_visibility" TEXT NOT NULL DEFAULT 'public';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -408,6 +408,7 @@ model UserConfig {
   userProfileId       String      @map("user_profile_id") @db.Uuid
   hasNewAnnouncements Boolean     @default(false) @map("has_new_announcements")
   notesVisibility     String      @default("public") @map("notes_visibility")
+  shelvesVisibility   String      @default("public") @map("shelves_visibility")
   createdAt           DateTime    @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt           DateTime?   @updatedAt @map("updated_at") @db.Timestamptz(6)
   userProfile         UserProfile @relation(fields: [userProfileId], references: [id], onDelete: Cascade)

--- a/src/app/api/user_configs/route.ts
+++ b/src/app/api/user_configs/route.ts
@@ -8,7 +8,7 @@ import type { NextRequest } from "next/server"
 
 export const PATCH = withApiHandling(async (_req: NextRequest, { params }) => {
   const { reqJson, currentUserProfile } = params
-  const { hasNewAnnouncements, notesVisibility } = reqJson
+  const { hasNewAnnouncements, notesVisibility, shelvesVisibility } = reqJson
 
   const existingUserConfig = await prisma.userConfig.findFirst({
     where: {
@@ -27,6 +27,7 @@ export const PATCH = withApiHandling(async (_req: NextRequest, { params }) => {
         userProfileId: currentUserProfile.id,
         hasNewAnnouncements,
         notesVisibility,
+        shelvesVisibility,
       },
     })
   }
@@ -34,10 +35,14 @@ export const PATCH = withApiHandling(async (_req: NextRequest, { params }) => {
   let isNotesVisibilityChanged = false
   if (notesVisibility) {
     if (!Object.values(Visibility).includes(notesVisibility)) {
-      return NextResponse.json({ error: "Invalid visibility value" }, { status: 400 })
+      return NextResponse.json({ error: "Invalid notes visibility value" }, { status: 400 })
     }
 
     isNotesVisibilityChanged = existingUserConfig?.notesVisibility !== notesVisibility
+  }
+
+  if (shelvesVisibility && !Object.values(Visibility).includes(shelvesVisibility)) {
+    return NextResponse.json({ error: "Invalid shelves visibility value" }, { status: 400 })
   }
 
   const updateUserConfigQuery = prisma.userConfig.update({
@@ -47,6 +52,7 @@ export const PATCH = withApiHandling(async (_req: NextRequest, { params }) => {
     data: {
       hasNewAnnouncements,
       notesVisibility,
+      shelvesVisibility,
     },
   })
 

--- a/src/app/components/forms/FormRadioGroup.tsx
+++ b/src/app/components/forms/FormRadioGroup.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, Fragment } from "react"
+import React, { useState, Fragment } from "react"
 import { RadioGroup } from "@headlessui/react"
 import { FaCheckCircle } from "react-icons/fa"
 
@@ -10,7 +10,7 @@ type Item = {
 }
 
 type Props = {
-  label?: string
+  label?: string | React.ReactNode
   helperText?: string
   items: Item[]
   defaultItemIndex?: number

--- a/src/app/settings/privacy/components/PrivacySettings.tsx
+++ b/src/app/settings/privacy/components/PrivacySettings.tsx
@@ -26,25 +26,44 @@ const options = {
       label: visibilitySettingsCopy[Visibility.Self],
     },
   ],
+  shelvesVisibility: [
+    {
+      value: Visibility.Public,
+      label: visibilitySettingsCopy[Visibility.Public],
+    },
+    {
+      value: Visibility.SignedIn,
+      label: visibilitySettingsCopy[Visibility.SignedIn],
+    },
+    {
+      value: Visibility.Friends,
+      label: visibilitySettingsCopy[Visibility.Friends],
+    },
+    {
+      value: Visibility.Self,
+      label: visibilitySettingsCopy[Visibility.Self],
+    },
+  ],
 }
 
 export default function PrivacySettings({ currentUserProfile }) {
-  const { notesVisibility: existingNotesVisibility } = currentUserProfile.config || {}
+  const { notesVisibility: existingNotesVisibility, shelvesVisibility: existingShelvesVisibility } =
+    currentUserProfile.config || {}
 
   const [notesVisibility, setNotesVisibility] = useState<Visibility>(
     existingNotesVisibility || Visibility.Public,
   )
+  const [shelvesVisibility, setShelvesVisibility] = useState<Visibility>(
+    existingShelvesVisibility || Visibility.Public,
+  )
   const [isBusy, setIsBusy] = useState<boolean>(false)
-
-  function handleNotesVisibilityChange(selectedItem) {
-    setNotesVisibility(selectedItem.value)
-  }
 
   async function handleSubmit() {
     setIsBusy(true)
 
     const requestData = {
       notesVisibility,
+      shelvesVisibility,
     }
 
     const toastId = toast.loading("Updating privacy settings...")
@@ -69,19 +88,44 @@ export default function PrivacySettings({ currentUserProfile }) {
     (item) => item.value === notesVisibility,
   )
 
+  const defaultShelvesVisibilityIndex = options.shelvesVisibility.findIndex(
+    (item) => item.value === shelvesVisibility,
+  )
+
+  const NotesVisibilityLabel = (
+    <div>
+      Who can see my <span className="text-gold-500">book notes</span>:
+    </div>
+  )
+
+  const ShelvesVisibilityLabel = (
+    <div>
+      Who can see my <span className="text-gold-500">shelves</span>:
+    </div>
+  )
+
   return (
     <div className="max-w-lg mx-8 sm:mx-auto font-mulish">
       <div className="cat-page-title">privacy and visibility settings</div>
 
       <div className="my-8">
-        <div className="">
-          <div className="my-2 cat-eyebrow-uppercase">book notes</div>
+        <div className="my-2">
           <FormRadioGroup
-            label="Make my book notes visible to:"
+            label={NotesVisibilityLabel}
             helperText="Your choice will apply to all your notes, including existing ones."
             defaultItemIndex={defaultNotesVisibilityIndex}
             items={options.notesVisibility}
-            onChange={handleNotesVisibilityChange}
+            onChange={(selectedItem) => setNotesVisibility(selectedItem.value as Visibility)}
+          />
+        </div>
+
+        <div className="my-8">
+          <FormRadioGroup
+            label={ShelvesVisibilityLabel}
+            helperText="Your shelves will still be included in any anonymized aggregate shelf stats that are shown."
+            defaultItemIndex={defaultShelvesVisibilityIndex}
+            items={options.shelvesVisibility}
+            onChange={(selectedItem) => setShelvesVisibility(selectedItem.value as Visibility)}
           />
         </div>
       </div>

--- a/src/app/users/[username]/(profilePages)/layout.tsx
+++ b/src/app/users/[username]/(profilePages)/layout.tsx
@@ -12,6 +12,7 @@ import UserProfileTabs from "app/users/[username]/components/UserProfileTabs"
 import CustomMarkdown from "app/components/CustomMarkdown"
 import { getUserProfileLink, getDomainFromUrl } from "lib/helpers/general"
 import { decorateWithFollowers } from "lib/server/decorators"
+import { areShelvesVisible } from "lib/api/userBookShelves"
 import UserProfile from "lib/models/UserProfile"
 
 export const dynamic = "force-dynamic"
@@ -75,6 +76,8 @@ export default async function UserProfileLayout({ params, children }) {
 
   const { name, bio, location, website, avatarUrl } = userProfile
 
+  const showShelves = await areShelvesVisible(userProfile, currentUserProfile)
+
   return (
     <div className="mt-4 xs:w-[400px] sm:w-[600px] lg:w-[960px] mx-8 xs:mx-auto">
       <div className="sm:flex font-mulish">
@@ -123,7 +126,7 @@ export default async function UserProfileLayout({ params, children }) {
         </div>
       </div>
       <div className="mt-12 mb-8">
-        <UserProfileTabs userProfile={decoratedUserProfile} />
+        <UserProfileTabs userProfile={decoratedUserProfile} shelves={showShelves} />
       </div>
       <div>{children}</div>
     </div>

--- a/src/app/users/[username]/(profilePages)/shelves/layout.tsx
+++ b/src/app/users/[username]/(profilePages)/shelves/layout.tsx
@@ -1,12 +1,16 @@
 import { notFound } from "next/navigation"
 import prisma from "lib/prisma"
+import { getCurrentUserProfile } from "lib/server/auth"
+import { areShelvesVisible } from "lib/api/userBookShelves"
 import UserShelvesTabs from "app/users/[username]/(profilePages)/shelves/components/UserShelvesTabs"
+import EmptyState from "app/components/EmptyState"
 import type { UserProfileProps as UserProfile } from "lib/models/UserProfile"
 
 export const dynamic = "force-dynamic"
 
 export default async function UserShelvesLayout({ params, children }) {
   const { username } = params
+  const currentUserProfile = await getCurrentUserProfile()
 
   const userProfile = (await prisma.userProfile.findFirst({
     where: {
@@ -15,6 +19,20 @@ export default async function UserShelvesLayout({ params, children }) {
   })) as UserProfile
 
   if (!userProfile) notFound()
+
+  const name = userProfile.displayName || userProfile.username
+
+  const shelvesVisible = await areShelvesVisible(userProfile, currentUserProfile)
+
+  if (!shelvesVisible) {
+    return (
+      <div className="">
+        <div className="sm:w-fit sm:mx-auto">
+          <EmptyState text={`${name}'s shelves are private.`} />
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="">

--- a/src/app/users/[username]/components/UserProfileTabs.tsx
+++ b/src/app/users/[username]/components/UserProfileTabs.tsx
@@ -15,7 +15,7 @@ function classNames(...classes) {
   return classes.filter(Boolean).join(" ")
 }
 
-export default function UserProfileTabs({ userProfile }) {
+export default function UserProfileTabs({ userProfile, shelves }) {
   const selectedLayoutSegment = useSelectedLayoutSegment()
 
   const { username } = userProfile
@@ -30,11 +30,16 @@ export default function UserProfileTabs({ userProfile }) {
       layoutPath: "lists",
       href: getUserListsLink(username),
     },
-    {
-      name: "shelves",
-      layoutPath: "shelves",
-      href: getUserShelvesLink(username),
-    },
+    // shelves tab dependent on prop
+    ...(shelves
+      ? [
+          {
+            name: "shelves",
+            layoutPath: "shelves",
+            href: getUserShelvesLink(username),
+          },
+        ]
+      : []),
     {
       name: "notes",
       layoutPath: "notes",


### PR DESCRIPTION
+ added user config `shelvesVisibility` column and added to privacy settings UI
+ the options are: public, signed-in, friends, and self
+ the chosen setting affects shelf visibility in the following places:
  + user's profile tabs - whether "shelves" link is visible
  + user's profile-shelves page - shows empty state with a message if not visible
  + book page - friends shelf activity
  + homepage (for signed-in users) - friends latest shelved books

also:
+ fixed bug (or at least unexpected behavior?) with book page friends shelf activity.. the existing behavior was to show the activity of the current user's _followers_, whereas I think the point of the feature is to show activity of the users the current user _follows_ .. so unless I had some rationale for implementing the existing behavior and did it on purpose (which I don't remember), it was a mistake and this PR fixes it.

https://app.asana.com/0/1205114589319956/1206007577807364