### PR TITLE
private current status

### DIFF
--- a/prisma/migrations/20240410201630_add_current_status_visibility_to_user_configs/migration.sql
+++ b/prisma/migrations/20240410201630_add_current_status_visibility_to_user_configs/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user_configs" ADD COLUMN     "current_status_visibility" TEXT NOT NULL DEFAULT 'public';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -404,14 +404,15 @@ model Comment {
 }
 
 model UserConfig {
-  id                  String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  userProfileId       String      @map("user_profile_id") @db.Uuid
-  hasNewAnnouncements Boolean     @default(false) @map("has_new_announcements")
-  notesVisibility     String      @default("public") @map("notes_visibility")
-  shelvesVisibility   String      @default("public") @map("shelves_visibility")
-  createdAt           DateTime    @default(now()) @map("created_at") @db.Timestamptz(6)
-  updatedAt           DateTime?   @updatedAt @map("updated_at") @db.Timestamptz(6)
-  userProfile         UserProfile @relation(fields: [userProfileId], references: [id], onDelete: Cascade)
+  id                      String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userProfileId           String      @map("user_profile_id") @db.Uuid
+  hasNewAnnouncements     Boolean     @default(false) @map("has_new_announcements")
+  notesVisibility         String      @default("public") @map("notes_visibility")
+  shelvesVisibility       String      @default("public") @map("shelves_visibility")
+  currentStatusVisibility String      @default("public") @map("current_status_visibility")
+  createdAt               DateTime    @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt               DateTime?   @updatedAt @map("updated_at") @db.Timestamptz(6)
+  userProfile             UserProfile @relation(fields: [userProfileId], references: [id], onDelete: Cascade)
 
   @@unique([userProfileId])
   @@map("user_configs")

--- a/src/app/api/home/activity/route.ts
+++ b/src/app/api/home/activity/route.ts
@@ -35,6 +35,7 @@ export const GET = withApiHandling(
 
     let friends = decoratedUserProfile.following
 
+    // filter out friends whose shelves are not visible to the current user
     const allFriendsCurrentUserFollows = await prisma.interaction.findMany({
       where: {
         agentId: {
@@ -46,7 +47,6 @@ export const GET = withApiHandling(
       },
     })
 
-    // filter out friends whose shelves are not visible to the current user
     friends = friends.filter((friend) => {
       const {
         config: { shelvesVisibility },

--- a/src/app/api/user_configs/route.ts
+++ b/src/app/api/user_configs/route.ts
@@ -8,7 +8,8 @@ import type { NextRequest } from "next/server"
 
 export const PATCH = withApiHandling(async (_req: NextRequest, { params }) => {
   const { reqJson, currentUserProfile } = params
-  const { hasNewAnnouncements, notesVisibility, shelvesVisibility } = reqJson
+  const { hasNewAnnouncements, notesVisibility, shelvesVisibility, currentStatusVisibility } =
+    reqJson
 
   const existingUserConfig = await prisma.userConfig.findFirst({
     where: {
@@ -28,6 +29,7 @@ export const PATCH = withApiHandling(async (_req: NextRequest, { params }) => {
         hasNewAnnouncements,
         notesVisibility,
         shelvesVisibility,
+        currentStatusVisibility,
       },
     })
   }
@@ -45,6 +47,10 @@ export const PATCH = withApiHandling(async (_req: NextRequest, { params }) => {
     return NextResponse.json({ error: "Invalid shelves visibility value" }, { status: 400 })
   }
 
+  if (currentStatusVisibility && !Object.values(Visibility).includes(currentStatusVisibility)) {
+    return NextResponse.json({ error: "Invalid current status visibility value" }, { status: 400 })
+  }
+
   const updateUserConfigQuery = prisma.userConfig.update({
     where: {
       userProfileId: currentUserProfile.id,
@@ -53,6 +59,7 @@ export const PATCH = withApiHandling(async (_req: NextRequest, { params }) => {
       hasNewAnnouncements,
       notesVisibility,
       shelvesVisibility,
+      currentStatusVisibility,
     },
   })
 

--- a/src/app/settings/privacy/components/PrivacySettings.tsx
+++ b/src/app/settings/privacy/components/PrivacySettings.tsx
@@ -44,17 +44,37 @@ const options = {
       label: visibilitySettingsCopy[Visibility.Self],
     },
   ],
+  currentStatusVisibility: [
+    {
+      value: Visibility.Public,
+      label: visibilitySettingsCopy[Visibility.Public],
+    },
+    {
+      value: Visibility.SignedIn,
+      label: visibilitySettingsCopy[Visibility.SignedIn],
+    },
+    {
+      value: Visibility.Friends,
+      label: visibilitySettingsCopy[Visibility.Friends],
+    },
+  ],
 }
 
 export default function PrivacySettings({ currentUserProfile }) {
-  const { notesVisibility: existingNotesVisibility, shelvesVisibility: existingShelvesVisibility } =
-    currentUserProfile.config || {}
+  const {
+    notesVisibility: existingNotesVisibility,
+    shelvesVisibility: existingShelvesVisibility,
+    currentStatusVisibility: existingCurrentStatusVisibility,
+  } = currentUserProfile.config || {}
 
   const [notesVisibility, setNotesVisibility] = useState<Visibility>(
     existingNotesVisibility || Visibility.Public,
   )
   const [shelvesVisibility, setShelvesVisibility] = useState<Visibility>(
     existingShelvesVisibility || Visibility.Public,
+  )
+  const [currentStatusVisibility, setCurrentStatusVisibility] = useState<Visibility>(
+    existingCurrentStatusVisibility || Visibility.Public,
   )
   const [isBusy, setIsBusy] = useState<boolean>(false)
 
@@ -64,6 +84,7 @@ export default function PrivacySettings({ currentUserProfile }) {
     const requestData = {
       notesVisibility,
       shelvesVisibility,
+      currentStatusVisibility,
     }
 
     const toastId = toast.loading("Updating privacy settings...")
@@ -92,6 +113,10 @@ export default function PrivacySettings({ currentUserProfile }) {
     (item) => item.value === shelvesVisibility,
   )
 
+  const defaultCurrentStatusVisibilityIndex = options.currentStatusVisibility.findIndex(
+    (item) => item.value === currentStatusVisibility,
+  )
+
   const NotesVisibilityLabel = (
     <div>
       Who can see my <span className="text-gold-500">book notes</span>:
@@ -101,6 +126,12 @@ export default function PrivacySettings({ currentUserProfile }) {
   const ShelvesVisibilityLabel = (
     <div>
       Who can see my <span className="text-gold-500">shelves</span>:
+    </div>
+  )
+
+  const CurrentStatusVisibilityLabel = (
+    <div>
+      Who can see my <span className="text-gold-500">current status</span>:
     </div>
   )
 
@@ -126,6 +157,18 @@ export default function PrivacySettings({ currentUserProfile }) {
             defaultItemIndex={defaultShelvesVisibilityIndex}
             items={options.shelvesVisibility}
             onChange={(selectedItem) => setShelvesVisibility(selectedItem.value as Visibility)}
+          />
+        </div>
+
+        <div className="my-8">
+          <FormRadioGroup
+            label={CurrentStatusVisibilityLabel}
+            helperText={`This refers to the current status you set for your profile (you can find this on your profile page or by going to "home").`}
+            defaultItemIndex={defaultCurrentStatusVisibilityIndex}
+            items={options.currentStatusVisibility}
+            onChange={(selectedItem) =>
+              setCurrentStatusVisibility(selectedItem.value as Visibility)
+            }
           />
         </div>
       </div>

--- a/src/app/users/[username]/(profilePages)/page.tsx
+++ b/src/app/users/[username]/(profilePages)/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation"
 import prisma from "lib/prisma"
 import { getCurrentUserProfile } from "lib/server/auth"
+import { isCurrentStatusVisible } from "lib/server/userCurrentStatuses"
 import { sortListsByPinSortOrder } from "lib/helpers/general"
 import { decorateLists, decorateWithLikes } from "lib/server/decorators"
 import { getMetadata } from "lib/server/metadata"
@@ -45,6 +46,8 @@ export default async function UserProfilePage({ params }) {
   })) as UserProfileProps
 
   if (!userProfile) notFound()
+
+  const showCurrentStatus = await isCurrentStatusVisible(userProfile, currentUserProfile)
 
   let favoriteBooksList = (await prisma.list.findFirst({
     where: {
@@ -127,6 +130,7 @@ export default async function UserProfilePage({ params }) {
       favoriteBooksList={favoriteBooksList}
       currentUserProfile={currentUserProfile}
       hasPinnedLists={hasPinnedLists}
+      showCurrentStatus={showCurrentStatus}
     />
   )
 }

--- a/src/app/users/[username]/components/UserProfilePageComponent.tsx
+++ b/src/app/users/[username]/components/UserProfilePageComponent.tsx
@@ -15,21 +15,24 @@ export default function UserProfilePageComponent({
   lists,
   favoriteBooksList,
   hasPinnedLists,
+  showCurrentStatus,
 }) {
   const isUsersProfile = currentUserProfile?.id === userProfile.id
 
   const { name } = UserProfile.build(userProfile)
 
   return (
-    <div className="mt-4 flex flex-col lg:flex-row">
-      <div className="lg:w-64 mt-4 lg:mr-16 font-mulish">
-        <ProfileCurrentStatus
-          userProfile={userProfile}
-          // @ts-ignore
-          userCurrentStatus={userProfile.currentStatuses[0]}
-          isUsersProfile={isUsersProfile}
-        />
-      </div>
+    <div className="mt-4 flex flex-col lg:flex-row justify-center">
+      {showCurrentStatus && (
+        <div className="lg:w-64 mt-4 lg:mr-16 font-mulish">
+          <ProfileCurrentStatus
+            userProfile={userProfile}
+            // @ts-ignore
+            userCurrentStatus={userProfile.currentStatuses[0]}
+            isUsersProfile={isUsersProfile}
+          />
+        </div>
+      )}
       <div className="xs:w-[400px] sm:w-[600px] lg:w-[640px] mt-8 lg:mt-4">
         <div className="font-mulish">
           <div className="cat-eyebrow">favorite books</div>

--- a/src/lib/server/userCurrentStatuses.ts
+++ b/src/lib/server/userCurrentStatuses.ts
@@ -1,0 +1,43 @@
+import prisma from "lib/prisma"
+import Visibility from "enums/Visibility"
+import InteractionType from "enums/InteractionType"
+import InteractionObjectType from "enums/InteractionObjectType"
+
+async function isCurrentStatusVisible(userProfile, currentUserProfile) {
+  if (currentUserProfile && userProfile.id === currentUserProfile.id) return true
+
+  let userConfig = userProfile.config
+
+  if (!userConfig) {
+    userConfig = await prisma.userConfig.findFirst({
+      where: {
+        userProfileId: userProfile.id,
+      },
+    })
+  }
+
+  const { currentStatusVisibility } = userConfig
+
+  if (currentStatusVisibility === Visibility.Public) return true
+
+  if (currentStatusVisibility === Visibility.SignedIn && currentUserProfile) {
+    return true
+  }
+
+  if (currentStatusVisibility === Visibility.Friends && currentUserProfile) {
+    const userFollowsCurrentUser = !!(await prisma.interaction.findFirst({
+      where: {
+        interactionType: InteractionType.Follow,
+        agentId: userProfile.id,
+        objectId: currentUserProfile.id,
+        objectType: InteractionObjectType.User,
+      },
+    }))
+
+    return userFollowsCurrentUser
+  }
+
+  return false
+}
+
+export { isCurrentStatusVisible }


### PR DESCRIPTION
+ add column to user configs for current status visibility
+ add to privacy settings UI with options: public, signed in, friends
+ setting affects visibility in the following places:
  + profile page - if not visible, the user current status section won't be displayed at all (as opposed to showing up but with empty state text, as when the current status is visible but there is none set)
  + homepage (signed in) friends current statuses
  + for any user mentions in the current status text, the user will only get a notif if the current status is visible to them.

https://app.asana.com/0/1205114589319956/1206007577807364