### PR TITLE
add book cover overlay three-dots menu

### DIFF
--- a/src/app/components/books/BookCoverOverlay.tsx
+++ b/src/app/components/books/BookCoverOverlay.tsx
@@ -5,6 +5,7 @@ import { reportToSentry } from "lib/sentry"
 import { useUser } from "lib/contexts/UserContext"
 import { useUserBooks } from "lib/contexts/UserBooksContext"
 import UserBookShelfMenu from "app/components/userBookShelves/UserBookShelfMenu"
+import BookCoverOverlayMenu from "app/components/books/BookCoverOverlayMenu"
 import type Book from "types/Book"
 
 export default function BookCoverOverlay({
@@ -61,13 +62,16 @@ export default function BookCoverOverlay({
 
   return (
     <div
-      className={`hidden group-hover:flex group-hover:z-50 absolute left-1/2 transform -translate-x-1/2 ${positionClass} bg-black bg-opacity-80 items-center justify-center`}
+      className={`hidden group-hover:flex group-hover:z-50 absolute left-1/2 transform -translate-x-1/2 ${positionClass} p-2 bg-black bg-opacity-80 items-center justify-center`}
     >
-      <button className="m-2" onClick={toggleLike}>
+      <button className="mr-1" onClick={toggleLike}>
         {isLiked ? <FaHeart className="text-red-300" /> : <FaRegHeart className="text-gray-500" />}
       </button>
-      <div className="m-2">
+      <div className="mx-1">
         <UserBookShelfMenu book={book} compact />
+      </div>
+      <div className="ml-0.5 -mr-0.5">
+        <BookCoverOverlayMenu book={book} />
       </div>
     </div>
   )

--- a/src/app/components/books/BookCoverOverlayMenu.tsx
+++ b/src/app/components/books/BookCoverOverlayMenu.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import Link from "next/link"
+import { Menu } from "@headlessui/react"
+import { Float } from "@headlessui-float/react"
+import { BsThreeDots } from "react-icons/bs"
+import { useModals } from "lib/contexts/ModalsContext"
+import { getBookLinkAgnostic } from "lib/helpers/general"
+import CurrentModal from "enums/CurrentModal"
+import type Book from "types/Book"
+
+type Props = {
+  book: Book
+}
+
+export default function BookCoverOverlayMenu({ book }: Props) {
+  const { setCurrentBook, setCurrentModal } = useModals()
+
+  const { title, authorName } = book
+
+  function handleAddBookToLists() {
+    setCurrentBook(book)
+    setCurrentModal(CurrentModal.AddBookToLists)
+  }
+
+  return (
+    <Menu>
+      <Float placement="right" offset={10} flip>
+        <Menu.Button className="flex items-center cat-btn-text text-sm">
+          <BsThreeDots className="text-gray-500 text-lg" />
+        </Menu.Button>
+        <Menu.Items className="w-[240px] bg-gray-900 rounded font-mulish text-sm">
+          <div className="px-4 py-2">
+            {title} by {authorName}
+          </div>
+
+          <hr className="my-1" />
+
+          <Menu.Item>
+            <button
+              onClick={handleAddBookToLists}
+              className="w-full hover:bg-gray-700 px-4 py-2.5 text-left first:rounded-tl first:rounded-tr last:rounded-bl last:rounded-br"
+            >
+              add book to list(s)
+            </button>
+          </Menu.Item>
+
+          <Menu.Item>
+            <Link href={getBookLinkAgnostic(book)}>
+              <button className="w-full hover:bg-gray-700 px-4 py-2.5 text-left first:rounded-tl first:rounded-tr last:rounded-bl last:rounded-br">
+                go to book page
+              </button>
+            </Link>
+          </Menu.Item>
+        </Menu.Items>
+      </Float>
+    </Menu>
+  )
+}

--- a/src/app/components/books/BookTooltip.tsx
+++ b/src/app/components/books/BookTooltip.tsx
@@ -18,17 +18,14 @@ export default function BookTooltip({ book, anchorSelect: _anchorSelect }) {
 
   const anchorSelect = _anchorSelect || `#book-${book.id}`
 
+  if (isMobile) return null
+
   return (
-    <Tooltip
-      anchorSelect={anchorSelect}
-      className="z-10 max-w-[240px] font-mulish"
-      clickable={isMobile}
-    >
+    <Tooltip anchorSelect={anchorSelect} className="z-10 max-w-[240px] font-mulish">
       <Link href={getBookLink(book.slug)}>
-        <button disabled={!isMobile}>
+        <button>
           <div className="text-center">{truncateString(`${book.title}`, 40)}</div>
           <div className="text-center">{truncateString(`by ${book.authorName}`, 40)}</div>
-          {isMobile && <div className="underline">Go to page</div>}
         </button>
       </Link>
     </Tooltip>


### PR DESCRIPTION
+ adds three-dots menu to book cover overlay, which includes:
  + title and author name
  + go to book page
  + add book to list(s)
+ removes BookTooltip if `isMobile` to simplify so that the popups don't interfere

https://app.asana.com/0/1205114589319956/1206926100526917