### PR TITLE
intro tour fix: full reload on sign in

### DIFF
--- a/src/app/components/nav/SignInForm.tsx
+++ b/src/app/components/nav/SignInForm.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useRouter, usePathname } from "next/navigation"
+import { usePathname } from "next/navigation"
 import { useState } from "react"
 import { useUser } from "lib/contexts/UserContext"
 import FormInput from "app/components/forms/FormInput"
@@ -8,7 +8,6 @@ import AuthForm from "enums/AuthForm"
 
 export default function SignInForm({ toggleAuth, onSuccess }) {
   const pathname = usePathname()
-  const router = useRouter()
   const { signIn } = useUser()
   const [email, setEmail] = useState<string>("")
   const [password, setPassword] = useState<string>("")
@@ -31,7 +30,7 @@ export default function SignInForm({ toggleAuth, onSuccess }) {
 
       onSuccess(currentUserProfile)
       if (pathname === "/") {
-        router.push("/home")
+        window.location.href = "/home"
       } else {
         window.location.reload()
       }


### PR DESCRIPTION
triggering a full page reload on sign in, same as on sign up (which was implemented in #180 ) should be harmless / generally good, and allows the intro tour prompt to show for existing users who sign in.