### PR TITLE
enable general invites

### DIFF
--- a/src/app/admin/invites/components/AdminInvites.tsx
+++ b/src/app/admin/invites/components/AdminInvites.tsx
@@ -2,26 +2,14 @@
 
 import Link from "next/link"
 import { useState, useEffect, useCallback } from "react"
-import toast from "react-hot-toast"
 import api from "lib/api"
-import { reportToSentry } from "lib/sentry"
 import { getUserProfileLink } from "lib/helpers/general"
-import { BASE_URLS_BY_ENV } from "lib/constants/urls"
-import CopyableText from "app/components/CopyableText"
+import CreateInvite from "app/components/invites/CreateInvite"
 
 export const dynamic = "force-dynamic"
 
-const env = process.env.NEXT_PUBLIC_CATALOG_ENV!
-const INVITE_LINK_BASE_URL = `${BASE_URLS_BY_ENV[env]}/sign-up?invite_code=`
-
 export default function AdminInvites() {
-  const [createdInvite, setCreatedInvite] = useState<any>()
-  const [errorMessage, setErrorMessage] = useState<string>()
   const [allInvites, setAllInvites] = useState<any[]>()
-
-  function getInviteUrl(inviteCode: string) {
-    return `${INVITE_LINK_BASE_URL}${inviteCode}`
-  }
 
   const getAllInvites = useCallback(async () => {
     const _allInvites = await api.invites.get()
@@ -32,49 +20,10 @@ export default function AdminInvites() {
     getAllInvites()
   }, [getAllInvites])
 
-  async function createInvite(singleUse: boolean) {
-    const requestData = {
-      singleUse,
-    }
-
-    const toastId = toast.loading("Creating invite...")
-
-    try {
-      const _createdInvite = await api.invites.create(requestData)
-
-      setCreatedInvite(_createdInvite)
-
-      toast.success("Invite created!", { id: toastId })
-
-      await getAllInvites()
-    } catch (error: any) {
-      reportToSentry(error)
-      setErrorMessage(error.message)
-      toast.error("Hmm, something went wrong.", { id: toastId })
-    }
-  }
-
   return (
     <div className="my-8 max-w-md mx-auto font-mulish">
-      <div className="mb-2">create an invite</div>
-      <button onClick={() => createInvite(true)} className="mr-4 cat-btn cat-btn-sm cat-btn-gold">
-        single
-      </button>
-      <button onClick={() => createInvite(false)} className="cat-btn cat-btn-sm cat-btn-gold">
-        multi (30-day)
-      </button>
-      <div className="my-2">
-        {createdInvite && (
-          <div>
-            <div>{createdInvite.expiresAt ? "30-day" : "single-use"} invite created!</div>
-            <CopyableText
-              displayText={createdInvite.code}
-              text={getInviteUrl(createdInvite.code)}
-            />
-          </div>
-        )}
-      </div>
-      {errorMessage && <div className="my-2 text-red-300">{errorMessage}</div>}
+      <CreateInvite isAdmin onSuccess={getAllInvites} />
+
       {allInvites && (
         <div className="my-8 text-sm">
           <table className="border-separate rounded bg-gray-800">

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,18 +1,15 @@
 import { notFound } from "next/navigation"
 import { getCurrentUserProfile } from "lib/server/auth"
-import UserRole from "enums/UserRole"
+import { isAdmin } from "lib/helpers/general"
 
 export const dynamic = "force-dynamic"
 
 export default async function AdminLayout({ children }) {
-  const currentUserProfile = await getCurrentUserProfile({ withRoles: true })
+  const currentUserProfile = await getCurrentUserProfile()
 
   if (!currentUserProfile) notFound()
 
-  const roles = currentUserProfile.roleAssignments.map((roleAssignment) => roleAssignment.role)
-  const isAdmin = roles.includes(UserRole.Admin)
-
-  if (!isAdmin) notFound()
+  if (!isAdmin(currentUserProfile)) notFound()
 
   return (
     <div className="">

--- a/src/app/components/invites/CreateInvite.tsx
+++ b/src/app/components/invites/CreateInvite.tsx
@@ -1,0 +1,91 @@
+"use client"
+
+import { useState } from "react"
+import toast from "react-hot-toast"
+import api from "lib/api"
+import { reportToSentry } from "lib/sentry"
+import { BASE_URLS_BY_ENV } from "lib/constants/urls"
+import CopyableText from "app/components/CopyableText"
+
+export const dynamic = "force-dynamic"
+
+const env = process.env.NEXT_PUBLIC_CATALOG_ENV!
+const INVITE_LINK_BASE_URL = `${BASE_URLS_BY_ENV[env]}/sign-up?invite_code=`
+
+type Props = {
+  onSuccess?: () => void
+  isAdmin?: boolean
+}
+
+export default function CreateInvite({ onSuccess, isAdmin = false }: Props) {
+  const [createdInvite, setCreatedInvite] = useState<any>()
+  const [errorMessage, setErrorMessage] = useState<string>()
+
+  function getInviteUrl(inviteCode: string) {
+    return `${INVITE_LINK_BASE_URL}${inviteCode}`
+  }
+
+  async function create(singleUse: boolean) {
+    const requestData = {
+      singleUse,
+    }
+
+    const toastId = toast.loading("Creating invite...")
+
+    try {
+      const _createdInvite = await api.invites.create(requestData)
+
+      setCreatedInvite(_createdInvite)
+
+      toast.success("Invite created!", { id: toastId })
+
+      if (onSuccess) await onSuccess()
+    } catch (error: any) {
+      reportToSentry(error)
+      setErrorMessage(error.message)
+      toast.error("Hmm, something went wrong.", { id: toastId })
+    }
+  }
+
+  return (
+    <div className="font-mulish">
+      {isAdmin ? (
+        <>
+          <div className="mb-2">create an invite</div>
+          <button onClick={() => create(true)} className="mr-4 cat-btn cat-btn-sm cat-btn-gold">
+            single
+          </button>
+          <button onClick={() => create(false)} className="cat-btn cat-btn-sm cat-btn-gold">
+            multi (30-day)
+          </button>
+        </>
+      ) : (
+        <>
+          <div className="mb-2">invite a friend</div>
+          <button onClick={() => create(true)} className="cat-btn cat-btn-sm cat-btn-gold">
+            {createdInvite ? "create another invite link" : "create an invite link"}
+          </button>
+          <div className="my-2 text-sm text-gray-300">
+            Each invite link can only be claimed once. You can create as many invite links as you
+            want. The links never expire.
+          </div>
+        </>
+      )}
+      <div className="my-2">
+        {createdInvite && (
+          <div>
+            <div>
+              {createdInvite.expiresAt ? "30-day" : "single-use"} invite created
+              {!isAdmin && " (click icon to copy the link)"}:
+            </div>
+            <CopyableText
+              displayText={createdInvite.code}
+              text={getInviteUrl(createdInvite.code)}
+            />
+          </div>
+        )}
+      </div>
+      {errorMessage && <div className="my-2 text-red-300">{errorMessage}</div>}
+    </div>
+  )
+}

--- a/src/app/components/nav/UserNav.tsx
+++ b/src/app/components/nav/UserNav.tsx
@@ -129,6 +129,15 @@ export default function UserNav({ currentUserProfile: _initialCurrentUserProfile
                     </Link>
                   </div>
                 </Menu.Item>
+                <Menu.Item>
+                  <div className="">
+                    <Link href={getUserFollowingLink(username)}>
+                      <button className="w-full hover:bg-gray-700 px-4 py-2 text-left text-gold-500 rounded-tl rounded-tr">
+                        invite
+                      </button>
+                    </Link>
+                  </div>
+                </Menu.Item>
                 <hr className="my-1 w-3/4 mx-auto border-gray-700" />
                 <Menu.Item>
                   <div className="">

--- a/src/app/users/[username]/(profilePages)/(friends)/layout.tsx
+++ b/src/app/users/[username]/(profilePages)/(friends)/layout.tsx
@@ -1,6 +1,8 @@
 import { notFound } from "next/navigation"
 import prisma from "lib/prisma"
+import CreateInvite from "app/components/invites/CreateInvite"
 import UserFriendsTabs from "app/users/[username]/(profilePages)/(friends)/components/UserFriendsTabs"
+import FeatureFlag from "enums/FeatureFlag"
 import type { UserProfileProps as UserProfile } from "lib/models/UserProfile"
 
 export const dynamic = "force-dynamic"
@@ -16,9 +18,23 @@ export default async function UserShelvesLayout({ params, children }) {
 
   if (!userProfile) notFound()
 
+  const generalInvitesFeatureFlag = await prisma.featureFlag.findFirst({
+    where: {
+      name: FeatureFlag.GeneralInvites,
+    },
+  })
+
+  const generalInvitesEnabled = generalInvitesFeatureFlag?.enabled
+
   return (
     <div className="">
       <div className="sm:w-fit sm:mx-auto">
+        {generalInvitesEnabled && (
+          <div className="mb-8">
+            <CreateInvite />
+          </div>
+        )}
+
         <UserFriendsTabs userProfile={userProfile} />
       </div>
       {children}

--- a/src/enums/FeatureFlag.ts
+++ b/src/enums/FeatureFlag.ts
@@ -1,5 +1,6 @@
 enum FeatureFlag {
   RequireInvites = "require_invites",
+  GeneralInvites = "general_invites",
 }
 
 export default FeatureFlag

--- a/src/lib/helpers/general.ts
+++ b/src/lib/helpers/general.ts
@@ -8,6 +8,7 @@ import { BASE_URLS_BY_ENV } from "lib/constants/urls"
 import CommentParentType from "enums/CommentParentType"
 import NotificationObjectType from "enums/NotificationObjectType"
 import InteractionObjectType from "enums/InteractionObjectType"
+import UserRole from "enums/UserRole"
 
 export const fetchJson = async (url: string | URL, options: any = {}) => {
   const TIMEOUT = 10_000 // 10 seconds
@@ -265,4 +266,11 @@ export function getWorldCatUrl({ isbn, oclc }: { isbn?: string; oclc?: string })
   if (isbn) return `${baseUrl}/isbn/${isbn}`
 
   return ""
+}
+
+export function isAdmin(userProfile) {
+  if (!userProfile?.roleAssignments) return false
+
+  const roles = userProfile.roleAssignments.map((roleAssignment) => roleAssignment.role)
+  return roles.includes(UserRole.Admin)
 }

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -11,14 +11,12 @@ import { reportToSentry } from "lib/sentry"
 type Options = {
   redirectPath?: string
   requireSignedIn?: boolean
-  withRoles?: boolean
   include?: any
 }
 
 const defaultOptions = {
   redirectPath: "/",
   requireSignedIn: false,
-  withRoles: false,
   include: undefined,
 }
 
@@ -29,7 +27,7 @@ const createServerSupabaseClient = cache(() => {
 })
 
 const getCurrentUserProfile = async (options: Options = {}) => {
-  const { redirectPath, requireSignedIn, withRoles, include } = { ...defaultOptions, ...options }
+  const { redirectPath, requireSignedIn, include } = { ...defaultOptions, ...options }
 
   const supabase = createServerSupabaseClient()
 
@@ -62,7 +60,7 @@ const getCurrentUserProfile = async (options: Options = {}) => {
         userId: session.user.id,
       },
       include: {
-        roleAssignments: withRoles,
+        roleAssignments: true,
         config: true,
         ...include,
       },

--- a/src/lib/server/metadata.ts
+++ b/src/lib/server/metadata.ts
@@ -4,8 +4,8 @@ import * as ghost from "lib/ghost"
 import { getCurrentUserProfile } from "lib/server/auth"
 import { getBookNoteById } from "lib/server/bookNotes"
 import { truncateString } from "lib/helpers/strings"
+import { isAdmin } from "lib/helpers/general"
 import UserProfile from "lib/models/UserProfile"
-import UserRole from "enums/UserRole"
 import type { Metadata } from "next"
 
 const METADATA_CONFIG = {
@@ -138,14 +138,11 @@ async function getMetadata({ key, params }): Promise<Metadata> {
         imageUrl = book.coverImageThumbnailUrl || undefined
       }
     } else if (key.match(/admin/)) {
-      const currentUserProfile = await getCurrentUserProfile({ withRoles: true })
+      const currentUserProfile = await getCurrentUserProfile()
 
       if (!currentUserProfile) return {}
 
-      const roles = currentUserProfile.roleAssignments.map((roleAssignment) => roleAssignment.role)
-      const isAdmin = roles.includes(UserRole.Admin)
-
-      if (!isAdmin) return {}
+      if (!isAdmin(currentUserProfile)) return {}
 
       pageTitle = config.title()
     } else if (key === "post" && postId) {


### PR DESCRIPTION
users can invite other users.

+ extracts "create invite" component to be shared by admin/invites as well as the user friends layout
+ from the general create invites section, users can create a single-use invite
+ this is behind a feature flag
+ also limits admin/invites to limit the fetch to the latest 100

https://app.asana.com/0/1205114589319956/1207303704339987