### PR TITLE
call wikidata api for author name, bio, wikipedia url

### DIFF
--- a/src/app/components/people/PersonPage.tsx
+++ b/src/app/components/people/PersonPage.tsx
@@ -13,7 +13,7 @@ import EmptyState from "app/components/EmptyState"
 const BOOKS_LIMIT = 8
 
 export default function PersonPage({ person }) {
-  const { openLibraryAuthorId, name, bio, photoUrl, books: allBooks } = person
+  const { openLibraryAuthorId, name, bio, photoUrl, books: allBooks, wikipediaUrl } = person
 
   const openLibraryUrl = `https://openlibrary.org/authors/${openLibraryAuthorId}`
 
@@ -48,8 +48,7 @@ export default function PersonPage({ person }) {
             <div className="mb-4 text-gray-300 italic">{bioPlaceholder}</div>
           )}
 
-          <div className="">
-            <span className="text-gray-200">View on</span>{" "}
+          <div className="my-1">
             <Link
               href={openLibraryUrl}
               className="cat-underline"
@@ -60,6 +59,20 @@ export default function PersonPage({ person }) {
             </Link>
             <TbExternalLink className="ml-1 -mt-1 inline-block" />
           </div>
+
+          {wikipediaUrl && (
+            <div className="my-1">
+              <Link
+                href={wikipediaUrl}
+                className="cat-underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Wikipedia
+              </Link>
+              <TbExternalLink className="ml-1 -mt-1 inline-block" />
+            </div>
+          )}
         </div>
 
         <div className="flex-grow mx-auto md:ml-16">

--- a/src/lib/constants/general.ts
+++ b/src/lib/constants/general.ts
@@ -1,0 +1,4 @@
+export const USER_AGENT_HEADERS = {
+  "User-Agent": "catalog.fyi/v0 (staff@catalog.fyi) Next.js/14",
+  "Api-User-Agent": "catalog.fyi/v0 (staff@catalog.fyi) Next.js/14",
+}

--- a/src/lib/helpers/general.ts
+++ b/src/lib/helpers/general.ts
@@ -5,6 +5,7 @@ import { validate as isValidUuid } from "uuid"
 import prisma from "lib/prisma"
 import { reportToSentry } from "lib/sentry"
 import { BASE_URLS_BY_ENV } from "lib/constants/urls"
+import { USER_AGENT_HEADERS } from "lib/constants/general"
 import CommentParentType from "enums/CommentParentType"
 import NotificationObjectType from "enums/NotificationObjectType"
 import InteractionObjectType from "enums/InteractionObjectType"
@@ -50,6 +51,9 @@ export const fetchJson = async (url: string | URL, options: any = {}) => {
     throw error
   }
 }
+
+export const fetchJsonWithUserAgentHeaders = async (url: string | URL, options: any = {}) =>
+  fetchJson(url, { ...options, headers: USER_AGENT_HEADERS })
 
 export const isValidHttpUrl = (string) => {
   let url

--- a/src/lib/wikidata.ts
+++ b/src/lib/wikidata.ts
@@ -1,0 +1,44 @@
+import { fetchJsonWithUserAgentHeaders } from "lib/helpers/general"
+
+const WIKIDATA_BASE_URL = "https://wikidata.org/w/rest.php/wikibase/v0"
+const WIKIDATA_ITEM_BASE_URL = `${WIKIDATA_BASE_URL}/entities/items`
+
+const WIKIPEDIA_BASE_URL = "https://en.wikipedia.org/api/rest_v1"
+const WIKIPEDIA_SUMMARY_BASE_URL = `${WIKIPEDIA_BASE_URL}/page/summary`
+
+const GET_ITEM_DEFAULT_OPTIONS = {
+  compact: false,
+}
+
+const Wikidata = {
+  getItem: async (id: string, options: any = GET_ITEM_DEFAULT_OPTIONS) => {
+    const { compact } = options
+
+    const url = `${WIKIDATA_ITEM_BASE_URL}/${id}`
+    const item = await fetchJsonWithUserAgentHeaders(url)
+
+    const { labels, sitelinks } = item
+
+    const name = labels.en
+    const { title: siteTitle, url: siteUrl } = sitelinks.enwiki
+
+    if (compact) {
+      return { name, siteTitle, siteUrl }
+    }
+
+    const siteUrlFragment = sitelinks.enwiki.url.split("/").pop()
+    const wikipediaSummaryUrl = `${WIKIPEDIA_SUMMARY_BASE_URL}/${siteUrlFragment}`
+
+    const wikipediaSummaryRes = await fetchJsonWithUserAgentHeaders(wikipediaSummaryUrl)
+    const wikipediaSummary = wikipediaSummaryRes.extract
+
+    return {
+      name,
+      siteTitle,
+      siteUrl,
+      summary: wikipediaSummary,
+    }
+  },
+}
+
+export default Wikidata


### PR DESCRIPTION
+ adds wikidata/wikipedia client object for looking up any item in general
+ our OL client calls the wikidata client (if wikidata id is present) for author name, bio, and wikipedia url
+ `OpenLibrary.getFullBook` also gets the author's wikidata english name if possible. this means that visiting a book's page will fix/update the author name (change it from OL to wikidata name) if possible.
  + the upshot is that the author's name can be from wikidata if the book is interacted with from the book page or "create list from book", but not in search results and not if the book is created via a bulk list create, or from the global create modal (although this latter might be doable as a followup).
+ adds helper to attach a user agent header with catalog's contact info to our outgoing requests- useful for calling api integrations.

https://app.asana.com/0/1205114589319956/1206043829613064