### PR TITLE
don't use Api-User-Agent header

### DIFF
--- a/src/lib/constants/general.ts
+++ b/src/lib/constants/general.ts
@@ -1,4 +1,3 @@
 export const USER_AGENT_HEADERS = {
   "User-Agent": "catalog.fyi/v0 (staff@catalog.fyi) Next.js/14",
-  "Api-User-Agent": "catalog.fyi/v0 (staff@catalog.fyi) Next.js/14",
 }


### PR DESCRIPTION
`Api-User-Agent` is kind of an optional fallback (for when `User-Agent` won't work) for the Wikidata api [docs here](https://www.mediawiki.org/wiki/API:REST_API#Authorization), but the OL search api won't accept it. so we can go without it in general until/unless we find out it's needed. fixes bug where OL search isn't working.