### PR TITLE
scripts and endpoints to process new authors

### DIFF
--- a/prisma/migrations/20240605014439_add_original_image_url_to_people/migration.sql
+++ b/prisma/migrations/20240605014439_add_original_image_url_to_people/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "people" ADD COLUMN     "original_image_url" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,7 @@ model Person {
   website             String?
   openLibraryAuthorId String?              @map("open_library_author_id")
   wikidataId          String?              @map("wikidata_id")
+  originalImageUrl    String?              @map("original_image_url")
   createdAt           DateTime             @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt           DateTime?            @updatedAt @map("updated_at") @db.Timestamptz(6)
   personBookRelations PersonBookRelation[]

--- a/scripts/backfillAuthors.ts
+++ b/scripts/backfillAuthors.ts
@@ -1,0 +1,346 @@
+// check DOTENV_PATH, BOOKS_LIMIT, and SLEEP_MS
+// for other env, create e.g. `.env.scripts.staging`
+// npx ts-node -P tsconfig.scripts.json scripts/backfillAuthors.ts
+
+import dotenv from "dotenv"
+
+const DOTENV_PATH = ".env"
+dotenv.config({ path: DOTENV_PATH })
+
+// eslint-disable-next-line
+import humps from "humps"
+// eslint-disable-next-line
+import prisma from "../src/lib/prisma"
+// eslint-disable-next-line
+import slugify from "slug"
+// eslint-disable-next-line
+import crypto from "crypto"
+// eslint-disable-next-line
+import PersonBookRelationType from "../src/enums/PersonBookRelationType"
+
+const BOOKS_LIMIT = 200
+const SLEEP_MS = 2000
+
+const BASE_URL = "https://openlibrary.org"
+const AUTHOR_IMAGE_BASE_URL = "https://covers.openlibrary.org/a/id"
+
+enum OpenLibraryCoverSize {
+  S = "S",
+  M = "M",
+  L = "L",
+}
+
+const WIKIDATA_BASE_URL = "https://wikidata.org/w/rest.php/wikibase/v0"
+const WIKIDATA_ITEM_BASE_URL = `${WIKIDATA_BASE_URL}/entities/items`
+
+const WIKIPEDIA_BASE_URL = "https://en.wikipedia.org/api/rest_v1"
+const WIKIPEDIA_SUMMARY_BASE_URL = `${WIKIPEDIA_BASE_URL}/page/summary`
+
+const GET_ITEM_DEFAULT_OPTIONS = {
+  compact: false,
+}
+
+const USER_AGENT_HEADERS = {
+  "User-Agent": "catalog.fyi/v0 (staff@catalog.fyi) Next.js/14",
+}
+
+function sleep(ms) {
+  // eslint-disable-next-line
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function getRandomHex() {
+  return crypto.randomBytes(3).toString("hex")
+}
+
+async function fetchJson(url: string | URL, options: any = {}) {
+  const TIMEOUT = 10_000 // 10 seconds
+
+  const fetchPromise = fetch(url, options)
+  const timeoutPromise = new Promise((_, reject) => {
+    setTimeout(() => reject(new Error("Request timed out")), TIMEOUT)
+  })
+
+  const res: any = await Promise.race([fetchPromise, timeoutPromise])
+
+  if (res.status < 200 || res.status >= 300) {
+    const resBody = await res.json()
+
+    if (resBody.error) {
+      throw new Error(resBody.error)
+    } else {
+      throw new Error(`Failed to fetch ${url}: ${res.status}`)
+    }
+  }
+
+  const resBody = await res.json()
+  return humps.camelizeKeys(resBody)
+}
+
+async function fetchJsonWithUserAgentHeaders(url: string | URL, options: any = {}) {
+  return fetchJson(url, { ...options, headers: USER_AGENT_HEADERS })
+}
+
+async function getWikidataItem(id: string, options: any = GET_ITEM_DEFAULT_OPTIONS) {
+  const { compact } = options
+
+  const url = `${WIKIDATA_ITEM_BASE_URL}/${id}`
+  const item = await fetchJsonWithUserAgentHeaders(url)
+
+  const { labels, sitelinks } = item
+
+  const name = labels.en
+  const { title: siteTitle, url: siteUrl } = sitelinks.enwiki
+
+  if (compact) {
+    return { name, siteTitle, siteUrl }
+  }
+
+  const siteUrlFragment = sitelinks.enwiki.url.split("/").pop()
+  const wikipediaSummaryUrl = `${WIKIPEDIA_SUMMARY_BASE_URL}/${siteUrlFragment}`
+
+  const wikipediaSummaryRes = await fetchJsonWithUserAgentHeaders(wikipediaSummaryUrl)
+  const wikipediaSummary = wikipediaSummaryRes.extract
+
+  let imageUrl
+  if (wikipediaSummaryRes.thumbnail) {
+    imageUrl = wikipediaSummaryRes.thumbnail.source
+  }
+
+  return {
+    name,
+    siteTitle,
+    siteUrl,
+    summary: wikipediaSummary,
+    imageUrl,
+  }
+}
+
+async function getOpenLibraryAuthorId(workId: string) {
+  // get work
+  const workUrl = `${BASE_URL}/works/${workId}.json`
+  const work = await fetchJsonWithUserAgentHeaders(workUrl)
+
+  // get author from work
+  const authorKey = work.authors?.[0]?.author?.key
+  const authorId = authorKey?.split("/authors/").pop()
+
+  return authorId
+}
+
+function getAuthorImageUrl(id: string | number, size: OpenLibraryCoverSize) {
+  return `${AUTHOR_IMAGE_BASE_URL}/${id}-${size}.jpg`
+}
+
+async function getAuthor(authorId: string) {
+  const authorUrl = `${BASE_URL}/authors/${authorId}.json`
+  let openLibraryAuthor = await fetchJsonWithUserAgentHeaders(authorUrl)
+
+  // follow a redirect
+  if (openLibraryAuthor.type.key === "/type/redirect") {
+    const nextAuthorKey = openLibraryAuthor.location
+    const nextAuthorUrl = `${BASE_URL}/${nextAuthorKey}.json`
+    openLibraryAuthor = await fetchJsonWithUserAgentHeaders(nextAuthorUrl)
+  }
+
+  const name = openLibraryAuthor.personalName || openLibraryAuthor.name
+  const bio = openLibraryAuthor.bio?.value
+  const photoId = openLibraryAuthor.photos?.[0]
+
+  let imageUrl
+  if (photoId) {
+    imageUrl = getAuthorImageUrl(photoId, OpenLibraryCoverSize.M)
+    console.log(`${name} has an image!`)
+  }
+
+  let authorName = name
+  let authorBio = bio
+  let wikipediaUrl
+
+  // get more author info from wikidata
+  const wikidataId = openLibraryAuthor.remoteIds?.wikidata
+  if (wikidataId) {
+    const wikidataRes = await getWikidataItem(wikidataId)
+    const {
+      name: wikidataName,
+      siteUrl,
+      summary: wikipediaBio,
+      imageUrl: wikipdiaImage,
+    } = wikidataRes || {}
+
+    authorName = wikidataName
+    authorBio = wikipediaBio
+    wikipediaUrl = siteUrl
+    imageUrl = wikipdiaImage || imageUrl
+  }
+
+  const author = {
+    name: authorName,
+    bio: authorBio,
+    imageUrl,
+    openLibraryAuthorId: authorId,
+    wikipediaUrl,
+    wikidataId,
+  }
+
+  return author
+}
+
+async function generateUniqueSlug(str, modelName, additionalFilters = {}) {
+  const MAX_BASE_LENGTH = 72
+  const simpleSlug = slugify(str).slice(0, MAX_BASE_LENGTH)
+  const simpleSlugFilters = { slug: simpleSlug, ...additionalFilters }
+  const isSimpleSlugAvailable = !(await (prisma[modelName] as any).findFirst({
+    where: simpleSlugFilters,
+  }))
+
+  if (isSimpleSlugAvailable) return simpleSlug
+
+  let slug
+  let isSlugTaken = true
+
+  /* eslint-disable no-await-in-loop */
+  while (isSlugTaken) {
+    const randomString = getRandomHex()
+    slug = `${simpleSlug}-${randomString}`
+    const filters = { slug, ...additionalFilters }
+    isSlugTaken = !!(await (prisma[modelName] as any).findFirst({ where: filters }))
+  }
+
+  return slug
+}
+
+async function main() {
+  let count = 0
+  let successCount = 0
+  const failures: any[] = []
+
+  // fetch books without person-book relations
+  const books = await prisma.book.findMany({
+    where: {
+      personBookRelations: {
+        none: {},
+      },
+    },
+    take: BOOKS_LIMIT,
+  })
+
+  console.log(`found ${books.length} books without person-book relations.`)
+  console.log(books.map((b) => b.slug))
+
+  // for each book, create the person (author) and the person-book relation
+  for (const book of books) {
+    await sleep(SLEEP_MS)
+
+    const { slug, openLibraryWorkId, authorName } = book
+    let { openLibraryAuthorId } = book
+
+    try {
+      console.log(`${count + 1}: starting ${slug}...`)
+
+      // fetch author id if needed
+      if (!openLibraryAuthorId) {
+        const authorId = await getOpenLibraryAuthorId(openLibraryWorkId!)
+
+        if (authorId) {
+          openLibraryAuthorId = authorId
+          console.log(`fetched author id ${authorId} for ${slug}`)
+        } else {
+          console.log(
+            `failed to fetch openLibraryAuthorId for ${slug}, proceeding without OL data...`,
+          )
+        }
+      }
+
+      // try to fetch author info
+      let author
+
+      if (openLibraryAuthorId) {
+        const existingPerson = await prisma.person.findFirst({
+          where: {
+            openLibraryAuthorId,
+          },
+        })
+
+        if (existingPerson) {
+          console.log(`found existing author ${existingPerson.name} for ${slug}`)
+
+          author = existingPerson
+        } else {
+          try {
+            console.log("calling OL...")
+
+            const openLibraryAuthor = await getAuthor(openLibraryAuthorId)
+
+            const authorSlug = await generateUniqueSlug(openLibraryAuthor.name, "person")
+
+            if (openLibraryAuthor) {
+              author = await prisma.person.create({
+                data: {
+                  slug: authorSlug,
+                  name: openLibraryAuthor.name,
+                  imageUrl: openLibraryAuthor.imageUrl,
+                  wikipediaUrl: openLibraryAuthor.wikipediaUrl,
+                  bio: openLibraryAuthor.bio,
+                  openLibraryAuthorId,
+                  wikidataId: openLibraryAuthor.wikidataId,
+                },
+              })
+            }
+
+            console.log(`created author ${author.name} from OL for ${slug}`)
+          } catch (error: any) {
+            console.log(
+              `creating from OL failed for ${slug} with error: ${error.message}. trying with just author name...`,
+            )
+          }
+        }
+      }
+
+      // if the above failed, create author person without extra info
+      if (!author && authorName) {
+        const authorSlug = await generateUniqueSlug(authorName, "person")
+
+        author = await prisma.person.create({
+          data: {
+            slug: authorSlug,
+            name: authorName,
+          },
+        })
+
+        console.log(`created author ${author.name} from authorName for ${slug}`)
+      }
+
+      // create person-book relation
+      console.log(`creating relation for ${author.name} and ${slug}...`)
+
+      if (author) {
+        await prisma.personBookRelation.create({
+          data: {
+            personId: author.id,
+            bookId: book.id,
+            relationType: PersonBookRelationType.Author,
+          },
+        })
+
+        console.log(`created relation for ${author.name} and ${slug}.`)
+      } else {
+        throw new Error(`failed to create author for ${slug}`)
+      }
+
+      successCount += 1
+    } catch (error: any) {
+      console.log(`failed to create author for ${slug} with error: ${error.message}`)
+      failures.push({ slug, error, errorMsg: error.message })
+    }
+
+    count += 1
+  }
+
+  console.log(`${successCount} authors created.`)
+  console.log("failures:")
+  console.log(failures)
+  console.log(`${failures.length} failures.`)
+}
+
+main()

--- a/src/app/api/people/process_new_authors/route.ts
+++ b/src/app/api/people/process_new_authors/route.ts
@@ -1,0 +1,185 @@
+import { NextResponse } from "next/server"
+import prisma from "lib/prisma"
+import OpenLibrary from "lib/openLibrary"
+import { generateUniqueSlug } from "lib/helpers/general"
+import { withApiHandling } from "lib/api/withApiHandling"
+import { reportToSentry } from "lib/sentry"
+import PersonBookRelationType from "enums/PersonBookRelationType"
+import type { NextRequest } from "next/server"
+
+const BOOKS_LIMIT = 30
+const SLEEP_MS = 2000
+
+function sleep(ms) {
+  // eslint-disable-next-line
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export const GET = withApiHandling(
+  async (req: NextRequest) => {
+    if (req.headers.get("Authorization") !== `Bearer ${process.env.CRON_SECRET}`) {
+      return NextResponse.json({ error: "Unauthorized " }, { status: 401 })
+    }
+
+    let successCount = 0
+    const failures: any[] = []
+
+    // fetch books without person-book relations
+    const whereConditions = {
+      personBookRelations: {
+        none: {},
+      },
+    }
+
+    const totalBooksToProcess = await prisma.book.count({
+      where: whereConditions,
+    })
+
+    if (totalBooksToProcess > BOOKS_LIMIT) {
+      reportToSentry(
+        `api.people.process_new_authors: found ${totalBooksToProcess} with authors to process, but only processing ${BOOKS_LIMIT}.`,
+      )
+    }
+
+    // fetch a batch
+    const books = await prisma.book.findMany({
+      where: whereConditions,
+      take: BOOKS_LIMIT,
+    })
+
+    console.log(
+      `api.people.process_new_authors: found ${books.length} books to process in this batch.`,
+    )
+
+    // for each book, fetch cover images, upload to supabase, and update book record
+    for (const book of books) {
+      await sleep(SLEEP_MS)
+
+      const { slug, openLibraryWorkId, authorName } = book
+      let { openLibraryAuthorId } = book
+
+      try {
+        // fetch author id if needed
+        if (!openLibraryAuthorId) {
+          const authorId = await OpenLibrary.getAuthorIdFromWorkId(openLibraryWorkId!)
+
+          if (authorId) {
+            openLibraryAuthorId = authorId
+            console.log(`api.people.process_new_authors: fetched author id ${authorId} for ${slug}`)
+          } else {
+            console.log(
+              `api.people.process_new_authors: failed to fetch openLibraryAuthorId for ${slug}, proceeding without OL data...`,
+            )
+          }
+        }
+
+        // try to fetch author info
+        let author
+
+        if (openLibraryAuthorId) {
+          const existingPerson = await prisma.person.findFirst({
+            where: {
+              openLibraryAuthorId,
+            },
+          })
+
+          if (existingPerson) {
+            console.log(
+              `api.people.process_new_authors: found existing author ${existingPerson.name} for ${slug}`,
+            )
+
+            author = existingPerson
+          } else {
+            try {
+              console.log("api.people.process_new_authors: calling OL...")
+
+              const openLibraryAuthor = await OpenLibrary.getAuthor(openLibraryAuthorId)
+
+              const authorSlug = await generateUniqueSlug(openLibraryAuthor.name, "person")
+
+              if (openLibraryAuthor) {
+                author = await prisma.person.create({
+                  data: {
+                    slug: authorSlug,
+                    name: openLibraryAuthor.name,
+                    imageUrl: openLibraryAuthor.imageUrl,
+                    wikipediaUrl: openLibraryAuthor.wikipediaUrl,
+                    bio: openLibraryAuthor.bio,
+                    openLibraryAuthorId,
+                    wikidataId: openLibraryAuthor.wikidataId,
+                  },
+                })
+              }
+
+              console.log(
+                `api.people.process_new_authors: created author ${author.name} from OL for ${slug}`,
+              )
+            } catch (error: any) {
+              console.log(
+                `api.people.process_new_authors: creating from OL failed for ${slug} with error: ${error.message}. trying with just author name...`,
+              )
+            }
+          }
+        }
+
+        // if the above failed, create author person without extra info
+        if (!author && authorName) {
+          const authorSlug = await generateUniqueSlug(authorName, "person")
+
+          author = await prisma.person.create({
+            data: {
+              slug: authorSlug,
+              name: authorName,
+            },
+          })
+
+          console.log(
+            `api.people.process_new_authors: created author ${author.name} from authorName for ${slug}`,
+          )
+        }
+
+        // create person-book relation
+        console.log(
+          `api.people.process_new_authors: creating relation for ${author.name} and ${slug}...`,
+        )
+
+        if (author) {
+          await prisma.personBookRelation.create({
+            data: {
+              personId: author.id,
+              bookId: book.id,
+              relationType: PersonBookRelationType.Author,
+            },
+          })
+
+          console.log(
+            `api.people.process_new_authors: created relation for ${author.name} and ${slug}.`,
+          )
+        } else {
+          throw new Error(`failed to create author for ${slug}`)
+        }
+
+        successCount += 1
+      } catch (error: any) {
+        reportToSentry(error, {
+          method: "api.books.process_new_authors",
+          bookSlug: slug,
+        })
+
+        failures.push({ slug, error, errorMsg: error.message })
+      }
+    }
+
+    console.log(`api.people.process_new_authors: ${successCount} books updated.`)
+    console.log("api.people.process_new_authors: failures:")
+    console.log(failures)
+    console.log(`api.people.process_new_authors: ${failures.length} failures.`)
+
+    return NextResponse.json({}, { status: 200 })
+  },
+  {
+    requireSession: false,
+    requireUserProfile: false,
+    requireJsonBody: false,
+  },
+)

--- a/src/app/api/people/process_new_images/route.ts
+++ b/src/app/api/people/process_new_images/route.ts
@@ -1,0 +1,118 @@
+import { NextResponse } from "next/server"
+import prisma from "lib/prisma"
+import { uploadPersonImage } from "lib/server/supabaseStorage"
+import { fetchImageAsBlob } from "lib/helpers/general"
+import { withApiHandling } from "lib/api/withApiHandling"
+import { reportToSentry } from "lib/sentry"
+import type { NextRequest } from "next/server"
+
+const PEOPLE_LIMIT = 30
+
+export const GET = withApiHandling(
+  async (req: NextRequest) => {
+    if (req.headers.get("Authorization") !== `Bearer ${process.env.CRON_SECRET}`) {
+      return NextResponse.json({ error: "Unauthorized " }, { status: 401 })
+    }
+
+    let successCount = 0
+    const failures: any[] = []
+
+    // where imageUrl is present but is not a supabase image
+    const whereConditions = {
+      imageUrl: {
+        not: null,
+      },
+      NOT: {
+        imageUrl: {
+          contains: "supabase",
+        },
+      },
+    }
+
+    const totalPeopleToProcess = await prisma.person.count({
+      where: whereConditions,
+    })
+
+    if (totalPeopleToProcess > PEOPLE_LIMIT) {
+      reportToSentry(
+        `api.people.process_new_images: found ${totalPeopleToProcess} with cover images to process, but only processing ${PEOPLE_LIMIT}.`,
+      )
+    }
+
+    // fetch a batch of people with images that haven't been processed
+    const people = await prisma.person.findMany({
+      where: whereConditions,
+      orderBy: {
+        createdAt: "asc",
+      },
+      take: PEOPLE_LIMIT,
+    })
+
+    console.log(
+      `api.people.process_new_images: found ${people.length} people with images in this batch.`,
+    )
+
+    // for each person, fetch image, upload to supabase, and update book record
+    for (const person of people) {
+      const { imageUrl, slug, id } = person
+
+      const baseOptions = {
+        personId: id,
+        personSlug: slug,
+        extension: imageUrl!.split(".").pop(),
+      }
+
+      try {
+        console.log(`api.people.process_new_images: starting ${slug}...`)
+        console.log(`api.people.process_new_images: ${slug}: fetching image...`)
+
+        const { blob, mimeType } = await fetchImageAsBlob(imageUrl)
+
+        console.log(`api.people.process_new_images: ${slug}: image fetched. uploading...`)
+
+        const options = {
+          ...baseOptions,
+          mimeType,
+        }
+
+        const supabaseUrl = await uploadPersonImage(blob, options)
+
+        console.log(`api.people.process_new_images: ${slug}: image uploaded. updating person...`)
+
+        await prisma.person.update({
+          where: {
+            id,
+          },
+          data: {
+            imageUrl: supabaseUrl,
+            originalImageUrl: imageUrl,
+          },
+        })
+
+        console.log(`api.people.process_new_images: ${slug} updated.`)
+
+        successCount += 1
+      } catch (error: any) {
+        reportToSentry(error, {
+          method: "api.people.process_new_images",
+          slug,
+          imageUrl,
+        })
+
+        failures.push({ slug, error, errorMsg: error.message })
+      }
+    }
+
+    console.log(`${successCount} people updated.`)
+    console.log("failures:")
+    console.log(failures)
+    console.log(`${failures.length} failures.`)
+
+    return NextResponse.json({}, { status: 200 })
+  },
+  {
+    requireSession: false,
+    requireUserProfile: false,
+    requireJsonBody: false,
+  },
+)

--- a/src/lib/wikidata.ts
+++ b/src/lib/wikidata.ts
@@ -32,11 +32,17 @@ const Wikidata = {
     const wikipediaSummaryRes = await fetchJsonWithUserAgentHeaders(wikipediaSummaryUrl)
     const wikipediaSummary = wikipediaSummaryRes.extract
 
+    let imageUrl
+    if (wikipediaSummaryRes.thumbnail) {
+      imageUrl = wikipediaSummaryRes.thumbnail.source
+    }
+
     return {
       name,
       siteTitle,
       siteUrl,
       summary: wikipediaSummary,
+      imageUrl,
     }
   },
 }


### PR DESCRIPTION
+ script: backfill people (authors) from books that aren't associated with any (to be run locally)
+ new api endpoint: same as above, to be run via hourly cron job
+ new api endpoint: copy new author images to supabase (and use our copy as the image url), to be run via hourly cron job

also:
+ adds column `people.original_image_url` to save the source of the image, when the record has been updated with our supabase image url
+ openlibrary getAuthor code follows author key redirects
+ use wikipedia image instead of OL image if available (whenever fetching author info), because it's better and more likely to be populated

https://app.asana.com/0/1205114589319956/1207476817286033