### PR TITLE
edit a person

### DIFF
--- a/prisma/migrations/20240612034323_add_edited_to_people/migration.sql
+++ b/prisma/migrations/20240612034323_add_edited_to_people/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "people" ADD COLUMN     "edited" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,6 +68,7 @@ model Person {
   openLibraryAuthorId String?              @map("open_library_author_id")
   wikidataId          String?              @map("wikidata_id")
   originalImageUrl    String?              @map("original_image_url")
+  edited              Boolean              @default(false)
   createdAt           DateTime             @default(now()) @map("created_at") @db.Timestamptz(6)
   updatedAt           DateTime?            @updatedAt @map("updated_at") @db.Timestamptz(6)
   personBookRelations PersonBookRelation[]

--- a/src/app/api/people/[personId]/route.ts
+++ b/src/app/api/people/[personId]/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from "next/server"
+import humps from "humps"
+import prisma from "lib/prisma"
+import { uploadPersonImage, deletePersonImage } from "lib/server/supabaseStorage"
+import { withApiHandling } from "lib/api/withApiHandling"
+import EditType from "enums/EditType"
+import EditedObjectType from "enums/EditedObjectType"
+import type { NextRequest } from "next/server"
+
+export const PATCH = withApiHandling(
+  async (req: NextRequest, { params }) => {
+    const { routeParams, currentUserProfile } = params
+    const { personId } = routeParams
+
+    const person = await prisma.person.findFirst({
+      where: {
+        id: personId,
+      },
+    })
+
+    if (!person) {
+      return NextResponse.json({ error: "Person not found" }, { status: 404 })
+    }
+
+    // unpack form data
+    const formData = await req.formData()
+    const json = formData.get("data") as string
+    const { person: reqJson, options } = humps.camelizeKeys(JSON.parse(json))
+
+    // handle image updates
+    const imageBlob = formData.get("imageFile") as Blob | null
+
+    let newImageUrl
+    let originalImageUrl
+
+    if ((imageBlob || options.imageDeleted) && person.imageUrl) {
+      if (person.imageUrl.match(/supabase/)) {
+        await deletePersonImage(person.imageUrl)
+      }
+
+      newImageUrl = null
+    }
+
+    if (imageBlob) {
+      const { imageMimeType, imageExtension } = options
+
+      const uploadedImageUrl = await uploadPersonImage(imageBlob, {
+        personId,
+        personSlug: person.slug,
+        mimeType: imageMimeType,
+        extension: imageExtension,
+        replace: true,
+      })
+
+      newImageUrl = uploadedImageUrl
+      originalImageUrl = null // since image comes from user, there is no "source" url
+    }
+
+    const { name, bio, location, website, wikipediaUrl } = reqJson
+
+    const fieldsToUpdate = {
+      name,
+      bio,
+      location,
+      website,
+      wikipediaUrl,
+      imageUrl: newImageUrl,
+      originalImageUrl,
+    }
+
+    const changedFields: string[] = []
+    Object.keys(fieldsToUpdate).forEach((key) => {
+      if (key === "originalImageUrl") return
+
+      if (person[key] !== fieldsToUpdate[key]) {
+        changedFields.push(key)
+      }
+    })
+
+    if (changedFields.length === 0) {
+      return NextResponse.json(reqJson, { status: 200 })
+    }
+
+    const updatedPerson = await prisma.person.update({
+      where: {
+        id: personId,
+      },
+      data: {
+        ...fieldsToUpdate,
+        edited: true,
+      },
+    })
+
+    // create edit logs
+    await prisma.editLog.create({
+      data: {
+        editorId: currentUserProfile.id,
+        editedObjectId: personId,
+        editedObjectType: EditedObjectType.Person,
+        editType: EditType.Update,
+        beforeJson: JSON.stringify(person),
+        afterJson: JSON.stringify(updatedPerson),
+        editedFields: changedFields,
+      },
+    })
+
+    const resBody = humps.decamelizeKeys(updatedPerson)
+
+    return NextResponse.json(resBody, { status: 200 })
+  },
+  { requireJsonBody: false },
+)

--- a/src/app/components/images/ImageCropModal.tsx
+++ b/src/app/components/images/ImageCropModal.tsx
@@ -81,7 +81,7 @@ const ImageCropModal = ({ isOpen, imageUrl, imageType, onModalClose, onSaveHandl
       <div className="fixed inset-0 flex w-screen items-center justify-center font-mulish">
         <Dialog.Panel className="relative rounded max-h-[90dvh] min-h-[80dvh] xs:min-h-[70dvh] sm:min-h-[60dvh] overflow-y-auto max-w-xs xs:max-w-md sm:max-w-xl md:max-w-none bg-gray-900 px-8 sm:px-16 py-8 flex flex-col">
           <Dialog.Title>
-            <div className="mb-8 text-center text-xl font-bold">avatar crop and resize</div>
+            <div className="mb-8 text-center text-xl font-bold">crop and resize</div>
           </Dialog.Title>
           <Dialog.Description>scroll to zoom, drag to move photo</Dialog.Description>
 

--- a/src/app/components/people/PersonPage.tsx
+++ b/src/app/components/people/PersonPage.tsx
@@ -1,9 +1,18 @@
 "use client"
 
+import { useSearchParams } from "next/navigation"
 import Link from "next/link"
+import { BsLink45Deg } from "react-icons/bs"
 import { FaUserCircle } from "react-icons/fa"
+import { MdEdit } from "react-icons/md"
+import { PiMapPinFill } from "react-icons/pi"
 import { TbExternalLink } from "react-icons/tb"
-import { getBookLinkAgnostic } from "lib/helpers/general"
+import {
+  getPersonEditLink,
+  getPersonEditLinkWithQueryString,
+  getBookLinkAgnostic,
+  getDomainFromUrl,
+} from "lib/helpers/general"
 import CoverPlaceholder from "app/components/books/CoverPlaceholder"
 import BookCoverOverlay from "app/components/books/BookCoverOverlay"
 import BookTooltip from "app/components/books/BookTooltip"
@@ -13,7 +22,19 @@ import EmptyState from "app/components/EmptyState"
 const BOOKS_LIMIT = 8
 
 export default function PersonPage({ person }) {
-  const { openLibraryAuthorId, name, bio, imageUrl, books: allBooks, wikipediaUrl } = person
+  const searchParams = useSearchParams()
+
+  const {
+    slug,
+    openLibraryAuthorId,
+    name,
+    bio,
+    imageUrl,
+    books: allBooks,
+    wikipediaUrl,
+    location,
+    website,
+  } = person
 
   const openLibraryUrl = `https://openlibrary.org/authors/${openLibraryAuthorId}`
 
@@ -35,6 +56,23 @@ export default function PersonPage({ person }) {
         <div className="my-6 sm:my-0 sm:ml-4 grow">
           <div className="text-2xl font-bold">
             <span data-intro-tour="profile-page">{name}</span>
+          </div>
+
+          <div className="flex flex-col sm:flex-row mt-3 text-gray-300">
+            {location && (
+              <div className="mr-4">
+                <PiMapPinFill className="inline-block -mt-[5px] mr-1" />
+                {location}
+              </div>
+            )}
+            {website && (
+              <div className="my-1 sm:my-0">
+                <BsLink45Deg className="inline-block -mt-[3px] mr-1 text-lg " />
+                <Link href={website} target="_blank" rel="noopener noreferrer">
+                  {getDomainFromUrl(website)}
+                </Link>
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -73,6 +111,19 @@ export default function PersonPage({ person }) {
               <TbExternalLink className="ml-1 -mt-1 inline-block" />
             </div>
           )}
+
+          <div className="">
+            <Link
+              href={
+                slug
+                  ? getPersonEditLink(slug)
+                  : getPersonEditLinkWithQueryString(searchParams.toString())
+              }
+              className="mt-4 mb-2 block text-sm text-gray-200 hover:text-white font-mulish"
+            >
+              <MdEdit className="inline-block -mt-[4px] text-sm" /> edit this person
+            </Link>
+          </div>
         </div>
 
         <div className="flex-grow mx-auto md:ml-16">

--- a/src/app/people/[personSlug]/edit/components/EditPerson.tsx
+++ b/src/app/people/[personSlug]/edit/components/EditPerson.tsx
@@ -1,0 +1,250 @@
+"use client"
+
+import { useState } from "react"
+import humps from "humps"
+import { useForm } from "react-hook-form"
+import { toast } from "react-hot-toast"
+import api from "lib/api"
+import { reportToSentry } from "lib/sentry"
+import { isValidHttpUrl, getPersonLinkWithSlug } from "lib/helpers/general"
+import FormInput from "app/components/forms/FormInput"
+import FormTextarea from "app/components/forms/FormTextarea"
+import AvatarUpload from "app/settings/profile/components/AvatarUpload"
+
+type PersonFormData = {
+  name: string
+  bio: string
+  location: string
+  website: string
+  wikipediaUrl: string
+  slug: string
+  openLibraryAuthorId: string
+  wikidataId: string
+}
+
+const MAX_LENGTHS = {
+  name: 200,
+  bio: 2500,
+  location: 40,
+}
+
+const validations = {
+  name: {
+    required: true,
+    maxLength: {
+      value: MAX_LENGTHS.name,
+      message: `Name cannot be longer than ${MAX_LENGTHS.name} characters.`,
+    },
+  },
+  bio: {
+    maxLength: {
+      value: MAX_LENGTHS.bio,
+      message: `Bio cannot be longer than ${MAX_LENGTHS.bio} characters.`,
+    },
+  },
+  location: {
+    maxLength: {
+      value: MAX_LENGTHS.location,
+      message: `Location cannot be longer than ${MAX_LENGTHS.location} characters.`,
+    },
+  },
+  website: {
+    validate: (value) => {
+      if (!value) return true
+      return isValidHttpUrl(value) || "Website needs to be a valid URL."
+    },
+  },
+  wikipediaUrl: {
+    pattern: {
+      value: /^https?:\/\/([a-z]+\.)?wikipedia\.org\/wiki\/[^ ]+$/,
+      message: "Must be a valid Wikipedia URL.",
+    },
+  },
+}
+
+export default function EditPerson({ person }) {
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
+  const [image, setImage] = useState<any>()
+  const [imageUrl, setImageUrl] = useState<string>(person.imageUrl)
+  const [imageChanged, setImageChanged] = useState<boolean>(false)
+  const [imageValid, setImageValid] = useState<boolean>(true)
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<PersonFormData>({
+    defaultValues: {
+      ...person,
+    },
+  })
+
+  const onImageChange = (file) => {
+    setImage(file)
+    setImageChanged(true)
+  }
+
+  const submit = async (data: PersonFormData) => {
+    if (!imageValid) return
+
+    const requestData = {
+      person: data,
+      options: {} as any,
+    }
+
+    const formData = new FormData()
+
+    if (imageChanged) {
+      if (image) {
+        formData.append("imageFile", image.file)
+        requestData.options.imageMimeType = image.fileType
+        requestData.options.imageExtension = image.fileExtension
+      } else {
+        requestData.options.imageDeleted = true
+      }
+    }
+
+    formData.append("data", JSON.stringify(humps.decamelizeKeys(requestData)))
+
+    setIsSubmitting(true)
+
+    const toastId = toast.loading("Saving your changes...")
+
+    try {
+      const updatedPerson = await api.people.update(person.id, formData)
+
+      const successMessage = (
+        <div className="flex flex-col ml-2">
+          Changes saved!&nbsp;
+          <a href={getPersonLinkWithSlug(person.slug)} className="underline">
+            Back to person's page
+          </a>
+        </div>
+      )
+
+      toast.success(successMessage, { id: toastId })
+
+      setImageValid(true)
+      setImageChanged(false)
+      setImageUrl(updatedPerson.imageUrl)
+    } catch (error: any) {
+      toast.error("Hmm, something went wrong.", { id: toastId })
+
+      reportToSentry(error, {
+        method: "EditPerson.submit",
+        ...requestData,
+      })
+    }
+
+    setIsSubmitting(false)
+  }
+
+  const nameValue = watch("name")
+  const bioValue = watch("bio")
+  const locationValue = watch("location")
+
+  const readyToSubmit = nameValue?.length > 0
+
+  return (
+    <div className="my-8 mx-8 sm:mx-16 ml:max-w-3xl ml:mx-auto font-mulish">
+      Please use English for all fields below, including the English spelling of the person's name.
+      <form onSubmit={handleSubmit(submit)}>
+        <div className="my-8 w-full sm:w-96">
+          <div className="my-8">
+            <AvatarUpload
+              initialFileUrl={imageUrl}
+              onFileChange={onImageChange}
+              markFileValid={setImageValid}
+            />
+          </div>
+
+          <FormInput
+            labelText="slug (not editable for now)"
+            name="slug"
+            type="text"
+            formProps={register("slug")}
+            fullWidth={false}
+            disabled
+          />
+          <FormInput
+            labelText="open library author id (not editable for now)"
+            name="openLibraryAuthorId"
+            type="text"
+            formProps={register("openLibraryAuthorId")}
+            fullWidth={false}
+            disabled
+          />
+          <FormInput
+            labelText="wikidata id (not editable for now)"
+            name="wikidataId"
+            type="text"
+            formProps={register("wikidataId")}
+            fullWidth={false}
+            disabled
+          />
+          <FormInput
+            labelText="name"
+            name="name"
+            type="text"
+            formProps={register("name", validations.name)}
+            remainingChars={MAX_LENGTHS.name - (nameValue?.length || 0)}
+            errorMessage={errors.name?.message}
+            fullWidth={false}
+          />
+          <FormTextarea
+            labelText="bio"
+            descriptionText="Use the person's bio from a reputable source, if possible."
+            name="bio"
+            type="text"
+            formProps={register("bio", validations.bio)}
+            rows={5}
+            remainingChars={MAX_LENGTHS.bio - (bioValue?.length || 0)}
+            errorMessage={errors.bio?.message}
+            fullWidth={false}
+            atMentionsEnabled={false}
+          />
+
+          <FormInput
+            labelText="location"
+            name="location"
+            type="text"
+            formProps={register("location", validations.location)}
+            remainingChars={MAX_LENGTHS.location - (locationValue?.length || 0)}
+            errorMessage={errors.location?.message}
+            fullWidth={false}
+          />
+          <FormInput
+            labelText="website"
+            descriptionText="The person's own official website, if they have one."
+            name="website"
+            type="text"
+            formProps={register("website", validations.website)}
+            errorMessage={errors.website?.message}
+            fullWidth={false}
+            placeholder="https://example.com"
+          />
+
+          <FormInput
+            labelText="wikipedia url"
+            name="wikipediaUrl"
+            type="text"
+            formProps={register("wikipediaUrl", validations.wikipediaUrl)}
+            errorMessage={errors.wikipediaUrl?.message}
+            fullWidth={false}
+          />
+
+          <div className="flex justify-between">
+            <button
+              type="submit"
+              className="cat-btn cat-btn-sm cat-btn-gold my-4"
+              disabled={isSubmitting || !readyToSubmit}
+            >
+              save
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/app/people/[personSlug]/edit/layout.tsx
+++ b/src/app/people/[personSlug]/edit/layout.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+// import { TiWarningOutline } from "react-icons/ti"
+import prisma from "lib/prisma"
+import { getCurrentUserProfile } from "lib/server/auth"
+import { getPersonLinkWithSlug } from "lib/helpers/general"
+
+export const dynamic = "force-dynamic"
+
+export default async function EditPersonLayout({ params, children }) {
+  const { personSlug } = params
+
+  await getCurrentUserProfile({
+    requireSignedIn: true,
+    redirectPath: getPersonLinkWithSlug(personSlug),
+  })
+
+  const person = await prisma.person.findFirst({
+    where: {
+      slug: personSlug,
+    },
+  })
+
+  if (!person) notFound()
+
+  return (
+    <div className="my-8 mx-8 sm:mx-16 ml:max-w-3xl ml:mx-auto font-mulish">
+      <div className="mt-8 mb-4 cat-page-title">
+        edit{" "}
+        <Link href={getPersonLinkWithSlug(personSlug)} className="underline">
+          {person.name}
+        </Link>{" "}
+      </div>
+      {/*
+      <div className="text-gray-300 text-sm">
+        <TiWarningOutline className="inline-block -mt-1 mr-1 text-lg text-gold-500" />
+        Make sure to save your changes before you switch tabs.
+      </div>
+      <div className="my-8 max-w-xl">
+        <EditBookTabs book={book} />
+      </div>
+      */}
+      {children}
+    </div>
+  )
+}

--- a/src/app/people/[personSlug]/edit/page.tsx
+++ b/src/app/people/[personSlug]/edit/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from "next/navigation"
+import prisma from "lib/prisma"
+import { getCurrentUserProfile } from "lib/server/auth"
+import { getMetadata } from "lib/server/metadata"
+import EditPerson from "app/people/[personSlug]/edit//components/EditPerson"
+import type Person from "types/Person"
+import type { Metadata } from "next"
+
+export const dynamic = "force-dynamic"
+
+export async function generateMetadata({ params }): Promise<Metadata> {
+  return getMetadata({
+    key: "person.edit",
+    params,
+  })
+}
+
+export default async function EditPersonPage({ params }) {
+  const { personSlug } = params
+
+  await getCurrentUserProfile({ requireSignedIn: true, redirectPath: `/people/${personSlug}` })
+
+  const person = (await prisma.person.findFirst({
+    where: {
+      slug: personSlug,
+    },
+  })) as Person
+
+  if (!person) notFound()
+
+  return <EditPerson person={person} />
+}

--- a/src/app/people/edit/page.tsx
+++ b/src/app/people/edit/page.tsx
@@ -1,0 +1,48 @@
+import { redirect, notFound } from "next/navigation"
+import humps from "humps"
+import prisma from "lib/prisma"
+import OpenLibrary from "lib/openLibrary"
+import { reportToSentry } from "lib/sentry"
+import { getPersonEditLink, generateUniqueSlug } from "lib/helpers/general"
+
+export const dynamic = "force-dynamic"
+
+export default async function EditPersonPage({ searchParams }) {
+  const { openLibraryAuthorId } = humps.camelizeKeys(searchParams)
+
+  if (!openLibraryAuthorId) notFound()
+
+  const existingPerson = await prisma.person.findFirst({
+    where: {
+      openLibraryAuthorId,
+    },
+  })
+
+  if (existingPerson) redirect(getPersonEditLink(existingPerson.slug))
+
+  let openLibraryAuthor: any = {}
+  try {
+    openLibraryAuthor = await OpenLibrary.getAuthor(openLibraryAuthorId)
+  } catch (error: any) {
+    reportToSentry(error, { openLibraryAuthorId })
+    notFound()
+  }
+
+  const { name, bio, imageUrl, wikipediaUrl, wikidataId } = openLibraryAuthor
+
+  const slug = await generateUniqueSlug(name, "person")
+
+  const createdPerson = await prisma.person.create({
+    data: {
+      slug,
+      name,
+      bio,
+      imageUrl,
+      wikipediaUrl,
+      openLibraryAuthorId,
+      wikidataId,
+    },
+  })
+
+  redirect(getPersonEditLink(createdPerson.slug))
+}

--- a/src/app/users/[username]/(profilePages)/edits/page.tsx
+++ b/src/app/users/[username]/(profilePages)/edits/page.tsx
@@ -62,14 +62,34 @@ export default async function UserEditsPage({ params }) {
     return acc
   }, {})
 
+  const personIds = _editLogs
+    .filter((editLog) => editLog.editedObjectType === EditedObjectType.Person)
+    .map((editLog) => editLog.editedObjectId)
+
+  const people = await prisma.person.findMany({
+    where: {
+      id: {
+        in: personIds,
+      },
+    },
+  })
+
+  const peopleById = people.reduce((acc, person) => {
+    acc[person.id] = person
+    return acc
+  }, {})
+
   const editLogs = _editLogs.map((editLog) => ({
     ...editLog,
-    book: booksById[editLog.editedObjectId],
+    editedObject:
+      editLog.editedObjectType === EditedObjectType.Book
+        ? booksById[editLog.editedObjectId]
+        : peopleById[editLog.editedObjectId],
   }))
 
   return (
     <div className="mt-4 max-w-3xl mx-auto font-mulish">
-      Book edits {isUsersProfile ? "you've" : `${name} has`} made.
+      Edits {isUsersProfile ? "you've" : `${name} has`} made.
       <div className="mt-4">
         {editLogs ? (
           editLogs.length > 0 ? (

--- a/src/app/users/[username]/(profilePages)/layout.tsx
+++ b/src/app/users/[username]/(profilePages)/layout.tsx
@@ -95,7 +95,7 @@ export default async function UserProfileLayout({ params, children }) {
           <div className="mt-2 max-w-lg">
             <CustomMarkdown markdown={bio} />
           </div>
-          <div className="flex mt-3 text-gray-300">
+          <div className="flex flex-col sm:flex-row mt-3 text-gray-300">
             {location && (
               <div className="mr-4">
                 <PiMapPinFill className="inline-block -mt-[5px] mr-1" />
@@ -103,7 +103,7 @@ export default async function UserProfileLayout({ params, children }) {
               </div>
             )}
             {website && (
-              <div>
+              <div className="my-1 sm:my-0">
                 <BsLink45Deg className="inline-block -mt-[3px] mr-1 text-lg " />
                 <Link href={website} target="_blank" rel="noopener noreferrer">
                   {getDomainFromUrl(website)}

--- a/src/enums/EditedObjectType.ts
+++ b/src/enums/EditedObjectType.ts
@@ -1,5 +1,6 @@
 enum EditedObjectType {
   Book = "book",
+  Person = "person",
 }
 
 export default EditedObjectType

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -279,6 +279,13 @@ const api = {
       return fetchJson(apiUrl)
     },
   },
+  people: {
+    update: (personId, formData) =>
+      fetchJson(`/api/people/${personId}`, {
+        method: "PATCH",
+        body: formData,
+      }),
+  },
   pins: {
     create: (requestData) =>
       fetchJson(`/api/pins`, {

--- a/src/lib/helpers/general.ts
+++ b/src/lib/helpers/general.ts
@@ -110,6 +110,10 @@ export const getPersonLinkAgnostic = (person) => {
   return getPersonLinkWithOpenLibraryId(person.openLibraryAuthorId)
 }
 
+export const getPersonEditLink = (slug: string) => `/people/${slug}/edit`
+
+export const getPersonEditLinkWithQueryString = (queryString: any) => `/people/edit?${queryString}`
+
 export const getBookEditLink = (slug: string) => `/books/${slug}/edit`
 
 export const getBookEditLinkWithQueryString = (queryString: any) => `/books/edit?${queryString}`

--- a/src/lib/server/metadata.ts
+++ b/src/lib/server/metadata.ts
@@ -73,6 +73,9 @@ const METADATA_CONFIG = {
   person: {
     title: (name) => `${name} • catalog`,
   },
+  "person.edit": {
+    title: (name) => `edit ${name} • catalog`,
+  },
 }
 
 async function getMetadata({ key, params }): Promise<Metadata> {
@@ -151,8 +154,10 @@ async function getMetadata({ key, params }): Promise<Metadata> {
 
       pageTitle = config.title(person.name)
 
-      pageDescription = person.bio || undefined
-      imageUrl = person.imageUrl || undefined
+      if (key === "person") {
+        pageDescription = person.bio || undefined
+        imageUrl = person.imageUrl || undefined
+      }
     } else if (key.match(/admin/)) {
       const currentUserProfile = await getCurrentUserProfile()
 

--- a/src/lib/server/supabaseStorage.ts
+++ b/src/lib/server/supabaseStorage.ts
@@ -72,7 +72,7 @@ async function uploadCoverImage(coverImageData, options) {
 async function uploadPersonImage(imageData, options) {
   const { personId, personSlug, mimeType, extension, replace = false } = options
 
-  // add a nonce to the filename to prevent caching issues when cover has changed
+  // add a nonce to the filename to prevent caching issues when image has changed
   const nonce = cryptoRandomString({ length: 6 })
 
   const fileDir = `people/images/${personId}`
@@ -103,4 +103,19 @@ async function uploadPersonImage(imageData, options) {
   return imageUrl
 }
 
-export { storageBucketPath, uploadAvatar, deleteAvatar, uploadCoverImage, uploadPersonImage }
+async function deletePersonImage(imageUrl) {
+  const filePath = imageUrl.split("/assets/").pop()
+
+  const { error: imageDeleteError } = await storageClient.from("assets").remove([filePath])
+
+  if (imageDeleteError) throw new Error(`Error deleting person image: ${imageDeleteError.message}`)
+}
+
+export {
+  storageBucketPath,
+  uploadAvatar,
+  deleteAvatar,
+  uploadCoverImage,
+  uploadPersonImage,
+  deletePersonImage,
+}

--- a/src/types/EditLog.ts
+++ b/src/types/EditLog.ts
@@ -13,4 +13,5 @@ export default interface EditLog {
   editedFields: string[]
   createdAt: Date
   editor: UserProfile
+  editedObject: any // Book | Person, in-memory only
 }

--- a/src/types/Person.ts
+++ b/src/types/Person.ts
@@ -11,6 +11,7 @@ export default interface Person {
   website?: string
   openLibraryAuthorId?: string
   wikidataId?: string
+  edited: boolean
   createdAt?: string | Date
   updatedAt?: string | Date
   books?: Book[]


### PR DESCRIPTION
+ add location and website to person page
+ add `people.edited` column
+ add "edit person" page with inputs and image upload component, incl. validations, submit flow
  + link to this page from the person page
+ add "edit person" api endpoint that accepts form data and handles image upload/deletion if needed
+ for an "external" person's edit page, create the person and then redirect to their edit page by slug
+ update EditLogCard to work for both edited books and people

https://app.asana.com/0/1205114589319956/1207476817286023