### PR TITLE
edit a person's books: fixes

### DIFF
--- a/src/app/api/people/[personId]/books/route.ts
+++ b/src/app/api/people/[personId]/books/route.ts
@@ -97,7 +97,7 @@ export const POST = withApiHandling(async (req: NextRequest, { params }) => {
   })
 
   const createPersonBookRelationsPromise = prisma.personBookRelation.createMany({
-    data: books.map((book) => ({
+    data: bookRecords.map((book) => ({
       personId,
       bookId: book.id,
       relationType: PersonBookRelationType.Author,

--- a/src/app/people/[personSlug]/edit/components/EditPersonBooks.tsx
+++ b/src/app/people/[personSlug]/edit/components/EditPersonBooks.tsx
@@ -43,7 +43,7 @@ export default function EditPersonBooks({ person }) {
   const [showDeleteAllConfirmation, setShowDeleteAllConfirmation] = useState(false)
 
   const suggestedBooks = openLibraryBooks
-    .filter((book) => !currentBooks.some((b) => b.id === book.id))
+    .filter((book) => !currentBooks.some((b) => b.openLibraryWorkId === book.openLibraryWorkId))
     .slice(0, BOOKS_LIMIT)
 
   // reset books when exiting editing mode


### PR DESCRIPTION
+ UI bug: when adding a suggested book that is not in the db, it removed all other non-db books from suggested (because it considers a null id to be equal to any other null id)
+ api endpoint bug: when adding books that weren't in the db (ie, are newly created) we need to use those newly created records to get their book ids