### PR TITLE
add job logs for process_new_authors

### DIFF
--- a/prisma/migrations/20240719030604_create_job_logs/migration.sql
+++ b/prisma/migrations/20240719030604_create_job_logs/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "job_logs" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "job_name" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "reason" TEXT,
+    "data" JSONB,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6),
+
+    CONSTRAINT "job_logs_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/migrations/20240719031841_add_reference_to_job_logs/migration.sql
+++ b/prisma/migrations/20240719031841_add_reference_to_job_logs/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "job_logs" ADD COLUMN     "reference" TEXT;

--- a/prisma/migrations/20240719032401_create_job_log_items/migration.sql
+++ b/prisma/migrations/20240719032401_create_job_log_items/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "job_log_items" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "job_log_id" UUID NOT NULL,
+    "status" TEXT NOT NULL,
+    "reason" TEXT,
+    "reference" TEXT,
+    "data" JSONB,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6),
+
+    CONSTRAINT "job_log_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "job_log_items_job_log_id_idx" ON "job_log_items"("job_log_id");

--- a/prisma/migrations/20240719032520_job_log_items_references_job_logs/migration.sql
+++ b/prisma/migrations/20240719032520_job_log_items_references_job_logs/migration.sql
@@ -1,0 +1,2 @@
+-- AddForeignKey
+ALTER TABLE "job_log_items" ADD CONSTRAINT "job_log_items_job_log_id_fkey" FOREIGN KEY ("job_log_id") REFERENCES "job_logs"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20240719033352_add_job_name_to_job_log_items/migration.sql
+++ b/prisma/migrations/20240719033352_add_job_name_to_job_log_items/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `job_name` to the `job_log_items` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "job_log_items" ADD COLUMN     "job_name" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,6 +56,36 @@ model FeedbackSubmission {
   @@map("feedback_submissions")
 }
 
+model JobLog {
+  id        String       @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  jobName   String       @map("job_name")
+  status    String       @map("status")
+  reference String?      @map("reference")
+  reason    String?      @map("reason")
+  data      Json?        @map("data")
+  createdAt DateTime     @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime?    @updatedAt @map("updated_at") @db.Timestamptz(6)
+  items     JobLogItem[]
+
+  @@map("job_logs")
+}
+
+model JobLogItem {
+  id        String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  jobLogId  String    @map("job_log_id") @db.Uuid
+  jobName   String    @map("job_name")
+  status    String    @map("status")
+  reason    String?   @map("reason")
+  reference String?   @map("reference")
+  data      Json?     @map("data")
+  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime? @updatedAt @map("updated_at") @db.Timestamptz(6)
+  jobLog    JobLog    @relation(fields: [jobLogId], references: [id], onDelete: Cascade)
+
+  @@index([jobLogId])
+  @@map("job_log_items")
+}
+
 model Person {
   id                  String               @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   name                String               @map("name")

--- a/src/enums/JobStatus.ts
+++ b/src/enums/JobStatus.ts
@@ -1,0 +1,8 @@
+enum JobStatus {
+  Started = "started",
+  Success = "success",
+  Failed = "failed",
+  PartialSuccess = "partial_success",
+}
+
+export default JobStatus


### PR DESCRIPTION
+ adds table job_logs for each job
+ adds table job_log_items for each item in a job (e.g. individual authors in a batch of authors to be created)
+ writes to these tables in api.people.process_new_authors
+ now relies on these logs, plus logger, to inform us of duplicates, rather than sentry

https://app.asana.com/0/1205114589319956/1207838531195214