### PR TITLE
Pagination component, pagination for user lists

### DIFF
--- a/src/app/components/Pagination.tsx
+++ b/src/app/components/Pagination.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import { useSearchParams, usePathname } from "next/navigation"
 import { useCallback } from "react"
-import { FaArrowLeft, FaArrowRight } from "react-icons/fa6"
+import { IoIosArrowRoundBack, IoIosArrowRoundForward } from "react-icons/io"
 
 const OVERFLOW_THRESHOLD = 7
 
@@ -19,8 +19,8 @@ function PageLink({ page, href, currentPage }) {
       href={href}
       aria-current={page === currentPage ? "page" : undefined}
       className={classNames(
-        page === currentPage && "font-bold",
-        "inline-flex items-center border-t-2 border-transparent px-4 pt-4 text-sm  text-gray-500 hover:border-gray-300 hover:text-gray-700",
+        page === currentPage ? "text-white border-gold-500" : "text-gray-300 border-transparent",
+        "border-t-2 px-3 pt-2.5 text-sm hover:text-white",
       )}
     >
       {page}
@@ -30,9 +30,7 @@ function PageLink({ page, href, currentPage }) {
 
 function Ellipsis() {
   return (
-    <span className="inline-flex items-center border-t-2 border-transparent px-4 pt-4 text-sm font-medium text-gray-500">
-      ...
-    </span>
+    <span className="border-t-2 border-transparent px-3 pt-2.5 text-sm text-gray-300">...</span>
   )
 }
 
@@ -109,31 +107,20 @@ export default function Pagination({ pageCount }) {
   if (pageCount === 1) return null
 
   return (
-    <nav className="flex items-center justify-between border-t border-gray-200 px-4 sm:px-0">
-      <div className="-mt-px flex w-0 flex-1">
-        {currentPage > 1 && (
-          <Link
-            href={getHref(currentPage - 1)}
-            className="inline-flex items-center border-t-2 border-transparent pr-1 pt-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700"
-          >
-            <FaArrowLeft aria-hidden="true" className="mr-3 size-5 text-gray-400" />
-          </Link>
-        )}
-      </div>
+    <nav className="flex justify-center border-t border-gray-500 font-mulish mt-2">
+      {currentPage > 1 && (
+        <Link href={getHref(currentPage - 1)} className="mr-3 pt-2.5 text-2xl">
+          <IoIosArrowRoundBack aria-hidden="true" className="text-gray-300 hover:text-white" />
+        </Link>
+      )}
       <div className="flex">
         <PageNumbers pageCount={pageCount} currentPage={currentPage} getHref={getHref} />
-        {/* Current: "border-indigo-500 text-indigo-600", Default: "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300" */}
       </div>
-      <div className="-mt-px flex w-0 flex-1 justify-end">
-        {currentPage < pageCount && (
-          <Link
-            href={getHref(currentPage + 1)}
-            className="inline-flex items-center border-t-2 border-transparent pl-1 pt-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700"
-          >
-            <FaArrowRight aria-hidden="true" className="ml-3 size-5 text-gray-400" />
-          </Link>
-        )}
-      </div>
+      {currentPage < pageCount && (
+        <Link href={getHref(currentPage + 1)} className="ml-3 pt-2.5 text-2xl">
+          <IoIosArrowRoundForward aria-hidden="true" className="text-gray-300 hover:text-white" />
+        </Link>
+      )}
     </nav>
   )
 }

--- a/src/app/components/Pagination.tsx
+++ b/src/app/components/Pagination.tsx
@@ -107,20 +107,30 @@ export default function Pagination({ pageCount }) {
   if (pageCount === 1) return null
 
   return (
-    <nav className="flex justify-center border-t border-gray-500 font-mulish mt-2">
-      {currentPage > 1 && (
-        <Link href={getHref(currentPage - 1)} className="mr-3 pt-2.5 text-2xl">
-          <IoIosArrowRoundBack aria-hidden="true" className="text-gray-300 hover:text-white" />
-        </Link>
-      )}
+    <nav className="flex justify-center border-t border-gray-500 font-mulish">
+      <Link
+        href={getHref(currentPage - 1)}
+        className={classNames(
+          // arrow element needs to exist but be invisible for page numbers to be centered properly
+          currentPage > 1 ? "visible" : "invisible pointer-events-none	",
+          "mr-3 pt-2.5 text-2xl",
+        )}
+      >
+        <IoIosArrowRoundBack aria-hidden="true" className="text-gray-300 hover:text-white" />
+      </Link>
+
       <div className="flex">
         <PageNumbers pageCount={pageCount} currentPage={currentPage} getHref={getHref} />
       </div>
-      {currentPage < pageCount && (
-        <Link href={getHref(currentPage + 1)} className="ml-3 pt-2.5 text-2xl">
-          <IoIosArrowRoundForward aria-hidden="true" className="text-gray-300 hover:text-white" />
-        </Link>
-      )}
+      <Link
+        href={getHref(currentPage + 1)}
+        className={classNames(
+          currentPage < pageCount ? "visible" : "invisible pointer-events-none	",
+          "ml-3 pt-2.5 text-2xl",
+        )}
+      >
+        <IoIosArrowRoundForward aria-hidden="true" className="text-gray-300 hover:text-white" />
+      </Link>
     </nav>
   )
 }

--- a/src/app/components/Pagination.tsx
+++ b/src/app/components/Pagination.tsx
@@ -1,0 +1,139 @@
+"use client"
+
+import Link from "next/link"
+import { useSearchParams, usePathname } from "next/navigation"
+import { useCallback } from "react"
+import { FaArrowLeft, FaArrowRight } from "react-icons/fa6"
+
+const OVERFLOW_THRESHOLD = 7
+
+function classNames(...classes) {
+  return classes.filter(Boolean).join(" ")
+}
+
+const range = (start, stop) => Array.from({ length: stop + 1 - start }, (_, i) => start + i)
+
+function PageLink({ page, href, currentPage }) {
+  return (
+    <Link
+      href={href}
+      aria-current={page === currentPage ? "page" : undefined}
+      className={classNames(
+        page === currentPage && "font-bold",
+        "inline-flex items-center border-t-2 border-transparent px-4 pt-4 text-sm  text-gray-500 hover:border-gray-300 hover:text-gray-700",
+      )}
+    >
+      {page}
+    </Link>
+  )
+}
+
+function Ellipsis() {
+  return (
+    <span className="inline-flex items-center border-t-2 border-transparent px-4 pt-4 text-sm font-medium text-gray-500">
+      ...
+    </span>
+  )
+}
+
+function PageNumbers({ pageCount, currentPage, getHref }) {
+  if (pageCount <= OVERFLOW_THRESHOLD) {
+    // 1 2 3 4 5 6
+    return (
+      <>
+        {range(1, pageCount).map((page) => (
+          <PageLink key={page} page={page} href={getHref(page)} currentPage={currentPage} />
+        ))}
+      </>
+    )
+  }
+
+  if (currentPage <= 3) {
+    // 1 2 3 4 ... 7
+    return (
+      <>
+        {range(1, 4).map((page) => (
+          <PageLink key={page} page={page} href={getHref(page)} currentPage={currentPage} />
+        ))}
+        <Ellipsis />
+        <PageLink page={pageCount} href={getHref(pageCount)} currentPage={currentPage} />
+      </>
+    )
+  }
+  if (currentPage >= 4 && currentPage <= pageCount - 3) {
+    // 1 ... 3 4 5 ... 7
+    return (
+      <>
+        <PageLink page={1} href={getHref(1)} currentPage={currentPage} />
+        <Ellipsis />
+        {range(currentPage - 1, currentPage + 1).map((page) => (
+          <PageLink key={page} page={page} href={getHref(page)} currentPage={currentPage} />
+        ))}
+        <Ellipsis />
+        <PageLink page={pageCount} href={getHref(pageCount)} currentPage={currentPage} />
+      </>
+    )
+  }
+  if (currentPage > pageCount - 4) {
+    // 1 ... 4 5 6 7
+    return (
+      <>
+        <PageLink page={1} href={getHref(1)} currentPage={currentPage} />
+        <Ellipsis />
+        {range(pageCount - 3, pageCount).map((page) => (
+          <PageLink key={page} page={page} href={getHref(page)} currentPage={currentPage} />
+        ))}
+      </>
+    )
+  }
+}
+
+export default function Pagination({ pageCount }) {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const currentPage = Number(searchParams.get("page")) || 1
+
+  const createQueryString = useCallback(
+    (name: string, value: string) => {
+      const params = new URLSearchParams(searchParams.toString())
+      params.set(name, value)
+
+      return params.toString()
+    },
+    [searchParams],
+  )
+
+  const getHref = (page) =>
+    page === 1 ? pathname : `${pathname}?${createQueryString("page", page.toString())}`
+
+  if (pageCount === 1) return null
+
+  return (
+    <nav className="flex items-center justify-between border-t border-gray-200 px-4 sm:px-0">
+      <div className="-mt-px flex w-0 flex-1">
+        {currentPage > 1 && (
+          <Link
+            href={getHref(currentPage - 1)}
+            className="inline-flex items-center border-t-2 border-transparent pr-1 pt-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700"
+          >
+            <FaArrowLeft aria-hidden="true" className="mr-3 size-5 text-gray-400" />
+          </Link>
+        )}
+      </div>
+      <div className="flex">
+        <PageNumbers pageCount={pageCount} currentPage={currentPage} getHref={getHref} />
+        {/* Current: "border-indigo-500 text-indigo-600", Default: "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300" */}
+      </div>
+      <div className="-mt-px flex w-0 flex-1 justify-end">
+        {currentPage < pageCount && (
+          <Link
+            href={getHref(currentPage + 1)}
+            className="inline-flex items-center border-t-2 border-transparent pl-1 pt-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700"
+          >
+            <FaArrowRight aria-hidden="true" className="ml-3 size-5 text-gray-400" />
+          </Link>
+        )}
+      </div>
+    </nav>
+  )
+}

--- a/src/app/components/Pagination.tsx
+++ b/src/app/components/Pagination.tsx
@@ -5,7 +5,12 @@ import { useSearchParams, usePathname } from "next/navigation"
 import { useCallback } from "react"
 import { IoIosArrowRoundBack, IoIosArrowRoundForward } from "react-icons/io"
 
+// there will be ellipses when there are this many pages or more
 const OVERFLOW_THRESHOLD = 7
+// when the current page is this far from the first or last pages, it will show the "middle pages" -
+// the current page in the center with previous and next pages and ellipses on either side.
+// note: changing this may result in the pagination not displaying correctly
+const MIDDLE_PAGES_DISPLAY_THRESHOLD = 3
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(" ")
@@ -46,11 +51,11 @@ function PageNumbers({ pageCount, currentPage, getHref }) {
     )
   }
 
-  if (currentPage <= 3) {
+  if (currentPage <= MIDDLE_PAGES_DISPLAY_THRESHOLD) {
     // 1 2 3 4 ... 7
     return (
       <>
-        {range(1, 4).map((page) => (
+        {range(1, MIDDLE_PAGES_DISPLAY_THRESHOLD + 1).map((page) => (
           <PageLink key={page} page={page} href={getHref(page)} currentPage={currentPage} />
         ))}
         <Ellipsis />
@@ -58,7 +63,10 @@ function PageNumbers({ pageCount, currentPage, getHref }) {
       </>
     )
   }
-  if (currentPage >= 4 && currentPage <= pageCount - 3) {
+  if (
+    currentPage > MIDDLE_PAGES_DISPLAY_THRESHOLD &&
+    currentPage <= pageCount - MIDDLE_PAGES_DISPLAY_THRESHOLD
+  ) {
     // 1 ... 3 4 5 ... 7
     return (
       <>
@@ -72,13 +80,13 @@ function PageNumbers({ pageCount, currentPage, getHref }) {
       </>
     )
   }
-  if (currentPage > pageCount - 4) {
+  if (currentPage >= pageCount - MIDDLE_PAGES_DISPLAY_THRESHOLD) {
     // 1 ... 4 5 6 7
     return (
       <>
         <PageLink page={1} href={getHref(1)} currentPage={currentPage} />
         <Ellipsis />
-        {range(pageCount - 3, pageCount).map((page) => (
+        {range(pageCount - MIDDLE_PAGES_DISPLAY_THRESHOLD, pageCount).map((page) => (
           <PageLink key={page} page={page} href={getHref(page)} currentPage={currentPage} />
         ))}
       </>
@@ -122,6 +130,7 @@ export default function Pagination({ pageCount }) {
       <div className="flex">
         <PageNumbers pageCount={pageCount} currentPage={currentPage} getHref={getHref} />
       </div>
+
       <Link
         href={getHref(currentPage + 1)}
         className={classNames(

--- a/src/app/users/[username]/(profilePages)/layout.tsx
+++ b/src/app/users/[username]/(profilePages)/layout.tsx
@@ -83,7 +83,7 @@ export default async function UserProfileLayout({ params, children }) {
       <div className="sm:flex font-mulish">
         {avatarUrl ? (
           <div className="shrink-0 sm:mr-3 w-24 h-24 overflow-hidden rounded-full">
-            <img src={avatarUrl} alt="user avatar" className="object-cover min-w-full min-h-full" />
+            {/* <img src={avatarUrl} alt="user avatar" className="object-cover min-w-full min-h-full" /> */}
           </div>
         ) : (
           <FaUserCircle className="mr-3 text-[96px] text-gray-500" />

--- a/src/app/users/[username]/(profilePages)/lists/page.tsx
+++ b/src/app/users/[username]/(profilePages)/lists/page.tsx
@@ -43,7 +43,7 @@ export default async function UserListsIndexPage({ params, searchParams }) {
     where: whereConditions,
   })
 
-  const pageCount = Math.floor(totalCount / LISTS_LIMIT)
+  const pageCount = Math.ceil(totalCount / LISTS_LIMIT)
 
   const _lists = await prisma.list.findMany({
     where: whereConditions,

--- a/src/app/users/[username]/(profilePages)/lists/page.tsx
+++ b/src/app/users/[username]/(profilePages)/lists/page.tsx
@@ -5,9 +5,10 @@ import { decorateLists } from "lib/server/decorators"
 import { getMetadata } from "lib/server/metadata"
 import ManageLists from "app/users/[username]/lists/components/ManageLists"
 import UserListsIndex from "app/users/[username]/lists/components/UsersListIndex"
+import Pagination from "app/components/Pagination"
 import type { Metadata } from "next"
 
-const LISTS_LIMIT = 8
+const LISTS_LIMIT = 2
 
 export const dynamic = "force-dynamic"
 
@@ -33,11 +34,19 @@ export default async function UserListsIndexPage({ params, searchParams }) {
   let { page } = await searchParams
   if (!page) page = 1
 
+  const whereConditions = {
+    ownerId: userProfile.id,
+    designation: null,
+  }
+
+  const totalCount = await prisma.list.count({
+    where: whereConditions,
+  })
+
+  const pageCount = Math.floor(totalCount / LISTS_LIMIT)
+
   const _lists = await prisma.list.findMany({
-    where: {
-      ownerId: userProfile.id,
-      designation: null,
-    },
+    where: whereConditions,
     orderBy: {
       createdAt: "desc",
     },
@@ -66,15 +75,30 @@ export default async function UserListsIndexPage({ params, searchParams }) {
 
   const isUsersProfile = currentUserProfile?.id === userProfile!.id
 
-  if (isUsersProfile) {
-    return <ManageLists lists={lists} pins={pins} />
-  } else {
-    return (
-      <UserListsIndex
-        lists={lists}
-        userProfile={userProfile}
-        currentUserProfile={currentUserProfile}
-      />
-    )
-  }
+  return (
+    <>
+      {isUsersProfile ? (
+        <ManageLists lists={lists} pins={pins} />
+      ) : (
+        <UserListsIndex
+          lists={lists}
+          userProfile={userProfile}
+          currentUserProfile={currentUserProfile}
+        />
+      )}
+      <Pagination pageCount={pageCount} />
+    </>
+  )
+
+  // if (isUsersProfile) {
+  //   return <ManageLists lists={lists} pins={pins} />
+  // } else {
+  //   return (
+  //     <UserListsIndex
+  //       lists={lists}
+  //       userProfile={userProfile}
+  //       currentUserProfile={currentUserProfile}
+  //     />
+  //   )
+  // }
 }

--- a/src/app/users/[username]/(profilePages)/lists/page.tsx
+++ b/src/app/users/[username]/(profilePages)/lists/page.tsx
@@ -7,6 +7,8 @@ import ManageLists from "app/users/[username]/lists/components/ManageLists"
 import UserListsIndex from "app/users/[username]/lists/components/UsersListIndex"
 import type { Metadata } from "next"
 
+const LISTS_LIMIT = 8
+
 export const dynamic = "force-dynamic"
 
 export async function generateMetadata({ params }): Promise<Metadata> {
@@ -16,7 +18,7 @@ export async function generateMetadata({ params }): Promise<Metadata> {
   })
 }
 
-export default async function UserListsIndexPage({ params }) {
+export default async function UserListsIndexPage({ params, searchParams }) {
   const { username } = params
   const currentUserProfile = await getCurrentUserProfile()
 
@@ -27,6 +29,9 @@ export default async function UserListsIndexPage({ params }) {
   })
 
   if (!userProfile) notFound()
+
+  let { page } = await searchParams
+  if (!page) page = 1
 
   const _lists = await prisma.list.findMany({
     where: {
@@ -43,6 +48,8 @@ export default async function UserListsIndexPage({ params }) {
         },
       },
     },
+    skip: LISTS_LIMIT * page,
+    take: LISTS_LIMIT,
   })
 
   const lists = await decorateLists(_lists, currentUserProfile)
@@ -62,6 +69,12 @@ export default async function UserListsIndexPage({ params }) {
   if (isUsersProfile) {
     return <ManageLists lists={lists} pins={pins} />
   } else {
-    return <UserListsIndex lists={lists} userProfile={userProfile} currentUserProfile={currentUserProfile} />
+    return (
+      <UserListsIndex
+        lists={lists}
+        userProfile={userProfile}
+        currentUserProfile={currentUserProfile}
+      />
+    )
   }
 }

--- a/src/app/users/[username]/(profilePages)/lists/page.tsx
+++ b/src/app/users/[username]/(profilePages)/lists/page.tsx
@@ -31,7 +31,7 @@ export default async function UserListsIndexPage({ params, searchParams }) {
 
   if (!userProfile) notFound()
 
-  let { page } = await searchParams
+  let { page } = searchParams
   if (!page) page = 1
 
   const whereConditions = {

--- a/src/app/users/[username]/(profilePages)/lists/page.tsx
+++ b/src/app/users/[username]/(profilePages)/lists/page.tsx
@@ -8,7 +8,7 @@ import UserListsIndex from "app/users/[username]/lists/components/UsersListIndex
 import Pagination from "app/components/Pagination"
 import type { Metadata } from "next"
 
-const LISTS_LIMIT = 1
+const LISTS_LIMIT = 8
 
 export const dynamic = "force-dynamic"
 
@@ -89,16 +89,4 @@ export default async function UserListsIndexPage({ params, searchParams }) {
       <Pagination pageCount={pageCount} />
     </>
   )
-
-  // if (isUsersProfile) {
-  //   return <ManageLists lists={lists} pins={pins} />
-  // } else {
-  //   return (
-  //     <UserListsIndex
-  //       lists={lists}
-  //       userProfile={userProfile}
-  //       currentUserProfile={currentUserProfile}
-  //     />
-  //   )
-  // }
 }

--- a/src/app/users/[username]/(profilePages)/lists/page.tsx
+++ b/src/app/users/[username]/(profilePages)/lists/page.tsx
@@ -8,7 +8,7 @@ import UserListsIndex from "app/users/[username]/lists/components/UsersListIndex
 import Pagination from "app/components/Pagination"
 import type { Metadata } from "next"
 
-const LISTS_LIMIT = 2
+const LISTS_LIMIT = 1
 
 export const dynamic = "force-dynamic"
 

--- a/src/app/users/[username]/(profilePages)/lists/page.tsx
+++ b/src/app/users/[username]/(profilePages)/lists/page.tsx
@@ -57,7 +57,7 @@ export default async function UserListsIndexPage({ params, searchParams }) {
         },
       },
     },
-    skip: LISTS_LIMIT * page,
+    skip: LISTS_LIMIT * (page - 1),
     take: LISTS_LIMIT,
   })
 

--- a/src/app/users/[username]/lists/components/ManageLists.tsx
+++ b/src/app/users/[username]/lists/components/ManageLists.tsx
@@ -119,7 +119,7 @@ export default function ManageLists({ lists, pins }) {
   }
 
   return (
-    <div className="mt-4 max-w-3xl mx-auto font-mulish">
+    <div className="my-4 max-w-3xl mx-auto font-mulish">
       <div className="mt-8 flex justify-end">
         <Link href={currentUser ? getNewListLink(currentUser) : ""}>
           <button className="cat-btn cat-btn-sm cat-btn-gray ml-4">+ Create a list</button>


### PR DESCRIPTION
We can follow what's done here in `lists/page.tsx` for the other paginated items throughout the site (except the search results page since it's different).

These screenshots are from setting `LISTS_LIMIT=1` in `lists/page.tsx` and going to http://localhost:3000/users/rory/lists. On the staging env, you can try out the pagination on my lists page but there are only 2 pages - https://catalog-git-rc-pagination-buidlers-fm.vercel.app/users/robyn/lists. 

<img width="653" alt="image" src="https://github.com/user-attachments/assets/59eee2b2-777b-4012-b543-aafc8b526356">

<img width="638" alt="Screenshot 2024-12-09 at 4 58 39 PM" src="https://github.com/user-attachments/assets/5e41ff5b-e26c-4ae3-92a7-c0e0c01180e0">

<img width="641" alt="Screenshot 2024-12-09 at 4 59 07 PM" src="https://github.com/user-attachments/assets/8bb67ccd-cd7c-4cc0-82af-22124a8587a3">

https://app.asana.com/0/1205114589319956/1205922189672180/f